### PR TITLE
Feature/cv 707/churaren abstract class

### DIFF
--- a/churaverse-plugins-client/src/churarenPlugin/churarenEngine/README.md
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenEngine/README.md
@@ -1,0 +1,6 @@
+## Churaverse Plugin: Churaren Engine (Client)
+
+### Description
+
+ちゅられんのBaseGamePluginとは別の親クラスを持つplugin(client側).
+ちゅられんで必要な定数やインターフェースを持つ.

--- a/churaverse-plugins-client/src/churarenPlugin/churarenEngine/README.md
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenEngine/README.md
@@ -2,5 +2,5 @@
 
 ### Description
 
-ちゅられんのBaseGamePluginとは別の親クラスを持つplugin(client側).
-ちゅられんで必要な定数やインターフェースを持つ.
+ちゅられんのBaseGamePluginとは別の親クラスが実装されたplugin(client側).
+ちゅられんで必要な定数やインターフェース等を持つ.

--- a/churaverse-plugins-client/src/churarenPlugin/churarenEngine/addDefAssetImport.ts
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenEngine/addDefAssetImport.ts
@@ -1,0 +1,32 @@
+declare module '*.png' {
+    const value: string;
+    export = value;
+}
+declare module '*.jpg' {
+    const value: string;
+    export = value;
+}
+declare module '*.webp' {
+    const value: string;
+    export = value;
+}
+declare module '*.module.css' {
+    const classes: Record<string, string>;
+    export default classes;
+}
+declare module '*.module.scss' {
+    const classes: Record<string, string>;
+    export default classes;
+}
+declare module '*.module.sass' {
+    const classes: Record<string, string>;
+    export default classes;
+}
+declare module '*.module.less' {
+    const classes: Record<string, string>;
+    export default classes;
+}
+declare module '*.module.style' {
+    const classes: Record<string, string>;
+    export default classes;
+}

--- a/churaverse-plugins-client/src/churarenPlugin/churarenEngine/churarenEngine.ts
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenEngine/churarenEngine.ts
@@ -1,0 +1,19 @@
+import { BasePlugin, IMainScene } from 'churaverse-engine-client'
+import { GameStartEvent } from '@churaverse/game-plugin-client/event/gameStartEvent'
+import { GameIds } from '@churaverse/game-plugin-client/interface/gameIds'
+
+export abstract class ChurarenEngine extends BasePlugin<IMainScene> {
+  public gameId!: GameIds
+  public listenEvent(): void {
+    this.bus.subscribeEvent('gameStart', this.gameStart.bind(this))
+  }
+
+  private gameStart(ev: GameStartEvent): void {
+    this.gameId = ev.gameId
+    this.handleGameStart()
+  }
+
+  protected abstract handleGameStart(): void
+
+  protected abstract handleGameTermination(): void
+}

--- a/churaverse-plugins-client/src/churarenPlugin/churarenEngine/constants/churarenConstants.ts
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenEngine/constants/churarenConstants.ts
@@ -1,0 +1,4 @@
+export const CHURAREN_CONSTANTS = {
+  GAME_ID: 'churaren',
+  GAME_NAME: 'ちゅられん',
+} as const

--- a/churaverse-plugins-client/src/churarenPlugin/churarenEngine/copyAssetsToDist.sh
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenEngine/copyAssetsToDist.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# コピー元の基本パス
+src_base="."
+# コピー先の基本パス
+dest_base="dist"
+
+# コピー元のパスを検索し、それぞれに対して処理を実行
+find "$src_base" -type d -name 'assets' | while read src_dir; do
+    # 対応するコピー先のディレクトリパスを生成
+    dest_dir="${src_dir/$src_base/$dest_base}"
+    # コピー元が dest_base ならスキップする処理
+    if [[ "$src_dir" == *"$dest_base"* ]]; then
+        continue
+    fi
+    # コピー先のディレクトリがなければ作成
+    mkdir -p "$dest_dir"
+    # ファイルをコピー先にコピー
+    cp -r "$src_dir/"* "$dest_dir"
+done
+
+echo "copied asset files"
+
+# コピー元のパスを検索し、それぞれに対して処理を実行
+find "$src_base" -type f -name '*.scss' | while read src_file; do
+    # 対応するコピー先のファイルパスを生成
+    dest_file="${src_file/$src_base/$dest_base}"
+    # コピー元が dest_base ならスキップする処理
+    if [[ "$src_file" == *"$dest_base"* ]]; then
+        continue
+    fi
+    # コピー先のディレクトリを取得
+    dest_dir=$(dirname "$dest_file")
+    # コピー先のディレクトリがなければ作成
+    mkdir -p "$dest_dir"
+    # ファイルをコピー先にコピー
+    cp "$src_file" "$dest_file"
+done
+
+echo "コピー完了"
+

--- a/churaverse-plugins-client/src/churarenPlugin/churarenEngine/index.ts
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenEngine/index.ts
@@ -1,0 +1,7 @@
+export { type IChurarenCollidable } from './model/IChurarenCollidable'
+export { type ChurarenWeaponEntity } from './model/churarenWeaponEntity'
+export { ChurarenWeaponDamageCause } from './model/churarenWeaponDamageCause'
+export { isWeaponEntity } from './util/isWeaponEntity'
+export { CHURAREN_CONSTANTS } from './constants/churarenConstants'
+export type { UpdateChurarenUiType, ChurarenUiState, ChurarenGameResult } from './types/uiTypes'
+export { ChurarenEngine } from './churarenEngine'

--- a/churaverse-plugins-client/src/churarenPlugin/churarenEngine/model/IChurarenCollidable.ts
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenEngine/model/IChurarenCollidable.ts
@@ -1,0 +1,11 @@
+import { DamageCauseType, Entity } from "churaverse-engine-client"
+
+/**
+ * ちゅられん用の当たり判定によるダメージのインターフェース
+ * @param collisionName 当たり判定の名前
+ * @param collisionEntity 当たり判定のエンティティ
+ */
+export interface IChurarenCollidable {
+  collisionName: DamageCauseType
+  collisionEntity: Entity
+}

--- a/churaverse-plugins-client/src/churarenPlugin/churarenEngine/model/churarenWeaponDamageCause.ts
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenEngine/model/churarenWeaponDamageCause.ts
@@ -1,0 +1,16 @@
+import { DamageCause, DamageCauseType } from 'churaverse-engine-client'
+import { ChurarenWeaponEntity } from './churarenWeaponEntity'
+
+/**
+ * ちゅられん用の武器によるダメージの抽象クラス
+ * @param churarenWeaponName 武器の名前
+ * @param churarenWeapon 武器のエンティティ
+ */
+export abstract class ChurarenWeaponDamageCause extends DamageCause {
+  public constructor(
+    public readonly churarenWeaponName: DamageCauseType,
+    public readonly churarenWeapon: ChurarenWeaponEntity
+  ) {
+    super(churarenWeaponName)
+  }
+}

--- a/churaverse-plugins-client/src/churarenPlugin/churarenEngine/model/churarenWeaponEntity.ts
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenEngine/model/churarenWeaponEntity.ts
@@ -1,0 +1,9 @@
+/**
+ * ちゅられんの武器エンティティ
+ * @param churarenWeaponOwnerId 武器を持っているユーザーのID
+ * @param power 武器のダメージ
+ */
+export interface ChurarenWeaponEntity {
+  readonly churarenWeaponOwnerId: string // 武器を持っているユーザーのID
+  readonly power: number // 武器のダメージ
+}

--- a/churaverse-plugins-client/src/churarenPlugin/churarenEngine/package.json
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenEngine/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@churaverse/churaren-engine-client",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc && bash copyAssetsToDist.sh",
+    "lint": "eslint src",
+    "format": "prettier --write src"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.27",
+    "@types/react": "^18.2.55",
+    "@types/react-dom": "^18.2.18",
+    "@types/uuid": "^9.0.8",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-config-standard-with-typescript": "^43.0.1",
+    "eslint-import-resolver-typescript": "^3.6.1",
+    "eslint-plugin-filename-rules": "^1.3.1",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-n": "^16.6.2",
+    "eslint-plugin-prettier": "^5.1.3",
+    "eslint-plugin-promise": "^6.1.1",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "prettier": "^3.2.5",
+    "sass": "^1.70.0",
+    "tiled-types": "^1.3.0",
+    "tsc-alias": "^1.8.8",
+    "typescript": "^5.2.2"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/types/index.d.ts",
+  "license": "MIT",
+  "dependencies": {
+    "@churaverse/game-plugin-client": "file:../../gamePlugin",
+    "churaverse-engine-client": "file:../../../../../churaverse-engine/churaverse-engine-client"
+  }
+}

--- a/churaverse-plugins-client/src/churarenPlugin/churarenEngine/tsconfig.json
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenEngine/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "jsx": "react-jsx",
+
+    /* Bundler mode */
+    "moduleResolution": "Bundler",
+    // "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    // "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationDir": "./dist/types",
+
+    /* Linting */
+    "strict": true,
+
+    "resolvePackageJsonExports": false,
+    "outDir": "./dist"
+  },
+  "include": ["."],
+  "exclude": ["node_modules", "dist"]
+}

--- a/churaverse-plugins-client/src/churarenPlugin/churarenEngine/types/uiTypes.ts
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenEngine/types/uiTypes.ts
@@ -1,0 +1,29 @@
+/**
+ * UIの種類
+ *
+ * ---
+ * UpdateChurarenUiType = ChurarenUiState | ChurarenGameResult
+ *
+ * ---
+ *
+ * プレイ画面の種類（ChurarenUiState）
+ *
+ * |||
+ * |---|---|
+ * |statCount|スタートカウント|
+ * |countTimer|カウントダウン|
+ *
+ * ---
+ *
+ * 結果画面の種類（ChurarenGameResult）
+ *
+ * |||
+ * |---|---|
+ * |timeOver|時間切れ|
+ * |win|ボスを倒した時|
+ * |gameOver|プレイヤーが全滅した時|
+ *
+ */
+export type UpdateChurarenUiType = ChurarenUiState | ChurarenGameResult
+export type ChurarenUiState = 'startCount' | 'countTimer'
+export type ChurarenGameResult = 'timeOver' | 'win' | 'gameOver'

--- a/churaverse-plugins-client/src/churarenPlugin/churarenEngine/util/isWeaponEntity.ts
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenEngine/util/isWeaponEntity.ts
@@ -1,0 +1,12 @@
+import { WeaponEntity } from "churaverse-engine-client";
+
+/**
+ * 武器かどうかを判定する
+ * @param entity 判定対象のエンティティ
+ * @returns 武器であればtrue
+ */
+export function isWeaponEntity(entity: any): entity is WeaponEntity {
+  return (
+    'ownerId' in entity && typeof entity.ownerId === 'string' && 'power' in entity && typeof entity.power === 'number'
+  )
+}


### PR DESCRIPTION
# 概要
BaseGamePluginを拡張した同じgameIdのクラスが複数作られるとゲーム開始のログが実装したクラス分流れたりするため、同じゲームのプラグインが複数あるのは良くないと考えた。そのため、BasePluginを拡張したゲーム開始時のイベントの登録や削除、ゲーム開始時の関数の実装などをもつ抽象クラスが必要だと考えた。

チケットへのリンク：https://churadata.backlog.com/view/CV-707

## 変更内容

- client側でBaseGamePluginとは別のイベントの登録等を持った抽象クラスの作成

## 補足

- ちゅられんで使用するインターフェースや定数等もここで保持している

