### PR TITLE
途中入室者に対するゲーム終了処理を暫定的に修正

### DIFF
--- a/churaverse-plugins-client/src/synchroBreakPlugin/synchroBreakPlugin.ts
+++ b/churaverse-plugins-client/src/synchroBreakPlugin/synchroBreakPlugin.ts
@@ -153,14 +153,15 @@ export class SynchroBreakPlugin extends BaseGamePlugin {
    */
   protected handleGameTermination(): void {
     this.unsubscribeGameEvent()
-    resetSynchroBreakPluginStore(this.store)
     this.socketController.unregisterMessageListener()
     this.synchroBreakDialogManager.setGameStartButtonText()
 
-    this.removeBetCoinUi()
-    this.resetPlayerNyokkiIcon()
-
-    this.gamePluginStore.gameUiManager.getUi(this.gameId, 'nyokkiButton')?.close()
+    if (this.participantIds.includes(this.playerPluginStore.ownPlayerId)) {
+      resetSynchroBreakPluginStore(this.store)
+      this.removeBetCoinUi()
+      this.resetPlayerNyokkiIcon()
+      this.gamePluginStore.gameUiManager.getUi(this.gameId, 'nyokkiButton')?.close()
+    }
   }
 
   /**


### PR DESCRIPTION
# 概要
[CV-736](https://churadata.backlog.com/view/CV-736)

## 変更内容
- 途中入室者とゲーム参加者の終了処理を分岐させることで、参照時エラーを根本的に防いだ

## 補足
現在、ゲーム終了時に gamePlugin 内で _isOwnPlayerMidwayParticipant をリセットするタイミングが handleGameTermination より前にあるため、同メソッド内で途中入室者かどうかを正しく判定できません。
そのため今回は暫定対応として、playerPluginStore のプレイヤーリストとゲーム参加者リストを比較して途中入室者を判定しています。
本チケットはシンクロブレイクのゲーム終了処理に関するものであるため、gamePlugin 側の修正は行っていません。

## チェックリスト
- [x] 最新の master ブランチを作業ブランチに取り込んでいますか？
- [x] 最後に Push したその状態は動作確認をしていますか？
- [x] File changed は確認しましたか？
   - print デバッグなどで使用した print 文や log 出力は消しましたか？
   - 不必要なメモや使わなくなったコード残していないですか？
   - 意図していない変更や修正が含まれていないですか？
   - 第三者が見てよくわからない命名などになっていませんか？
- [x] マージできる状態になっていますか？
   - コンフリクトは起きていないですか？