### PR TITLE
Feature/cv-744/modify-synchro-break-async-process

### DIFF
--- a/churaverse-plugins-server/src/synchroBreakPlugin/interface/IGame.ts
+++ b/churaverse-plugins-server/src/synchroBreakPlugin/interface/IGame.ts
@@ -1,6 +1,4 @@
-import { SynchroBreakPluginStore } from '../store/defSynchroBreakPluginStore'
-
 export interface IGame {
+  getPluginStores: () => void
   processTurnSequence: () => Promise<void>
-  getSynchroBreakPluginStore: (synchroBreakPluginStore: SynchroBreakPluginStore) => void
 }

--- a/churaverse-plugins-server/src/synchroBreakPlugin/store/synchroBreakPluginStoreManager.ts
+++ b/churaverse-plugins-server/src/synchroBreakPlugin/store/synchroBreakPluginStoreManager.ts
@@ -1,5 +1,6 @@
 import { Store, IEventBus, IMainScene } from 'churaverse-engine-server'
 import '@churaverse/player-plugin-server/store/defPlayerPluginStore'
+import { GameIds } from '@churaverse/game-plugin-server/interface/gameIds'
 import { SynchroBreakPluginStore } from './defSynchroBreakPluginStore'
 import { Game } from '../logic/game'
 import { NyokkiRepository } from '../repository/nyokkiRepository'
@@ -10,9 +11,13 @@ import { NyokkiLogTextCreate } from '../logic/nyokkiLogTextCreate'
 /**
  * SynchroBreakPluginStoreを初期化する関数
  */
-export function initSynchroBreakPluginStore(eventBus: IEventBus<IMainScene>, store: Store<IMainScene>): void {
+export function initSynchroBreakPluginStore(
+  gameId: GameIds,
+  eventBus: IEventBus<IMainScene>,
+  store: Store<IMainScene>
+): void {
   const synchroBreakPluginStore: SynchroBreakPluginStore = {
-    game: new Game(eventBus, store),
+    game: new Game(gameId, eventBus, store),
     nyokkiRepository: new NyokkiRepository(),
     playersCoinRepository: new PlayersCoinRepository(),
     betCoinRepository: new BetCoinRepository(),

--- a/churaverse-plugins-server/src/synchroBreakPlugin/synchroBreakPlugin.ts
+++ b/churaverse-plugins-server/src/synchroBreakPlugin/synchroBreakPlugin.ts
@@ -73,10 +73,10 @@ export class SynchroBreakPlugin extends CoreGamePlugin {
    * シンクロブレイク特有の開始時に実行される処理
    */
   protected handleGameStart(): void {
-    initSynchroBreakPluginStore(this.bus, this.store)
+    initSynchroBreakPluginStore(this.gameId, this.bus, this.store)
     this.socketController.registerMessageListener()
     this.synchroBreakPluginStore = this.store.of('synchroBreakPlugin')
-    this.synchroBreakPluginStore.game.getSynchroBreakPluginStore(this.synchroBreakPluginStore)
+    this.synchroBreakPluginStore.game.getPluginStores()
     for (const playerId of this.participantIds) {
       this.synchroBreakPluginStore.playersCoinRepository.set(playerId, this.initialPlayerCoins)
     }


### PR DESCRIPTION
# 概要
https://churadata.backlog.com/view/CV-744

## 変更内容

- 現在のシンクロブレイクでは、タイマーをカウントダウン中にゲームを中断すると、タイマーが動作したままになり、秒数カウントのメッセージが飛んでくる。

## チェックリスト
- [x] 最新の master ブランチを作業ブランチに取り込んでいますか？
- [x] 最後に Push したその状態は動作確認をしていますか？
- [x] File changed は確認しましたか？
  - print デバッグなどで使用した print 文や log 出力は消しましたか？
  - 不必要なメモや使わなくなったコード残していないですか？
  - 意図していない変更や修正が含まれていないですか？
  - 第三者が見てよくわからない命名などになっていませんか？
- [x] マージできる状態になっていますか？
  - コンフリクトは起きていないですか？