### PR TITLE
gamePluginの関数の修正

### DIFF
--- a/churaverse-plugins-client/src/gamePlugin/domain/baseGamePlugin.ts
+++ b/churaverse-plugins-client/src/gamePlugin/domain/baseGamePlugin.ts
@@ -45,9 +45,9 @@ export abstract class BaseGamePlugin extends BasePlugin<IMainScene> {
 
   private getPriorGameData(ev: PriorGameDataEvent): void {
     if (!this.isActive) return
-    this.handleMidwayParticipant()
     // 途中参加者はonGameStartではなく、getPriorGameDataでsubscribeGameEventする
     this.subscribeGameEvent()
+    this.handleMidwayParticipant()
   }
 
   private onGameStart(ev: GameStartEvent): void {

--- a/churaverse-plugins-client/src/gamePlugin/domain/coreGamePlugin.ts
+++ b/churaverse-plugins-client/src/gamePlugin/domain/coreGamePlugin.ts
@@ -65,6 +65,7 @@ export abstract class CoreGamePlugin extends BaseGamePlugin implements IGameInfo
   }
 
   public getStores(): void {
+    super.getStores()
     this.gamePluginStore = this.store.of('gamePlugin')
     this.networkPluginStore = this.store.of('networkPlugin')
   }


### PR DESCRIPTION
## 概要
`getPriorGameData`での`subscribeGameEvent()`を`handleMidwayParticipant()`より先に実行することでゲーム毎で途中参加者を扱いやすくしたい。
`CoreGamePlugin`で、継承した`BaseGamePlugin`の`getStores()`を呼び出していないことで、`this.gameInfo = undefined`になっているためその修正を行う。

チケットへのリンク：https://churadata.backlog.com/view/CV-773

## 変更内容
- `CoreGamePlugin`内の`getPriorGameData`で`subscribeGameEvent()`を`handleMidwayParticipant()`より先に実行する。
- `CoreGamePlugin`で、継承した`BaseGamePlugin`の`getStores()`の呼び出し

