### PR TITLE
churarenPlayerPluginでのダメージ処理

### DIFF
--- a/churaverse-plugins-client/src/churarenPlugin/churarenBossPlugin/churarenBossPlugin.ts
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenBossPlugin/churarenBossPlugin.ts
@@ -68,6 +68,10 @@ export class ChurarenBossPlugin extends BaseGamePlugin {
 
   private init(): void {
     this.playerPluginStore = this.store.of('playerPlugin')
+    this.playerPluginStore.deathLogRenderer.addDeathLogMessageBuilder(
+      'collisionBoss',
+      (deathLog) => `${deathLog.victim.name} がボスに潰された！ ${deathLog.victim.name} は死んでしまった！`
+    )
   }
 
   public handleGameStart(): void {
@@ -110,16 +114,6 @@ export class ChurarenBossPlugin extends BaseGamePlugin {
     this.bossPluginStore.bossRenderers.delete(bossId)
   }
 
-  private addDamageCauseLog(attacker: Player, cause: DamageCauseType, damage: number): void {
-    const damageCauseLog: BossDamageCauseLog = {
-      attacker,
-      cause,
-      damage,
-    }
-    this.bossPluginStore.damageCauseLogRenderer.add(damageCauseLog)
-    this.bossPluginStore.damageCauseLogRepository.addDamageCauseLog(damageCauseLog)
-  }
-
   private readonly moveBoss = (ev: BossWalkEvent): void => {
     const boss = this.bossPluginStore.bosses.get(ev.id)
     if (boss === undefined) return
@@ -159,5 +153,15 @@ export class ChurarenBossPlugin extends BaseGamePlugin {
       if (attacker === undefined) return
       this.addDamageCauseLog(attacker, ev.cause.name, ev.amount)
     }
+  }
+
+  private addDamageCauseLog(attacker: Player, cause: DamageCauseType, damage: number): void {
+    const damageCauseLog: BossDamageCauseLog = {
+      attacker,
+      cause,
+      damage,
+    }
+    this.bossPluginStore.damageCauseLogRenderer.add(damageCauseLog)
+    this.bossPluginStore.damageCauseLogRepository.addDamageCauseLog(damageCauseLog)
   }
 }

--- a/churaverse-plugins-client/src/churarenPlugin/churarenBossPlugin/controller/socketController.ts
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenBossPlugin/controller/socketController.ts
@@ -15,7 +15,7 @@ import { BossSpawnMessage } from '../message/bossSpawnMessage'
 import { BossDespawnMessage } from '../message/bossDespawnMessage'
 import { BossWalkMessage } from '../message/bossWalkMessage'
 import { Boss } from '../domain/boss'
-import { WeaponDamageMessage } from '@churaverse/player-plugin-client/message/weaponDamageMessage'
+import { ChurarenDamageMessage } from '@churaverse/churaren-player-plugin-client/message/churarenDamageMessage'
 import { CollisionBossDamageCause } from '../domain/collisionBossDamageCause'
 import { BossWalkEvent } from '../event/bossWalkEvent'
 import { IMessageListenerRegister } from '@churaverse/network-plugin-client/interface/IMessageListenerRegister'
@@ -45,14 +45,14 @@ export class SocketController extends BaseSocketController<IMainScene> {
   public registerMessageListener(): void {
     this.messageListenerRegister.on('bossSpawn', this.bossSpawn)
     this.messageListenerRegister.on('bossDespawn', this.bossDespawn)
-    this.messageListenerRegister.on('weaponDamage', this.collisionBossDamage)
+    this.messageListenerRegister.on('churarenDamage', this.collisionBossDamage)
     this.messageListenerRegister.on('bossWalk', this.bossWalk)
   }
 
   public unregisterMessageListener(): void {
     this.messageListenerRegister.off('bossSpawn', this.bossSpawn)
     this.messageListenerRegister.off('bossDespawn', this.bossDespawn)
-    this.messageListenerRegister.off('weaponDamage', this.collisionBossDamage)
+    this.messageListenerRegister.off('churarenDamage', this.collisionBossDamage)
     this.messageListenerRegister.off('bossWalk', this.bossWalk)
   }
 
@@ -73,11 +73,11 @@ export class SocketController extends BaseSocketController<IMainScene> {
     this.eventBus.post(bossDespawnEvent)
   }
 
-  private readonly collisionBossDamage = (msg: WeaponDamageMessage): void => {
+  private readonly collisionBossDamage = (msg: ChurarenDamageMessage): void => {
     const data = msg.data
     if (data.cause !== 'collisionBoss') return
     const target = this.store.of('playerPlugin').players.get(data.targetId)
-    const boss = this.bossPluginStore.bosses.get(data.weaponId)
+    const boss = this.bossPluginStore.bosses.get(data.sourceId)
     const attacker = boss?.bossId
     if (target === undefined || boss === undefined || attacker === undefined) return
     const collisionBossDamageCause = new CollisionBossDamageCause(boss)

--- a/churaverse-plugins-client/src/churarenPlugin/churarenBossPlugin/package.json
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenBossPlugin/package.json
@@ -35,6 +35,7 @@
   "license": "MIT",
   "dependencies": {
     "@churaverse/churaren-core-plugin-client": "file:../churarenCorePlugin",
+    "@churaverse/churaren-player-plugin-client": "file:../churarenPlayerPlugin",
     "@churaverse/core-ui-plugin-client": "^0.1.1",
     "@churaverse/debug-screen-plugin-client": "~0.1.0",
     "@churaverse/game-plugin-client": "file:../../gamePlugin",

--- a/churaverse-plugins-client/src/churarenPlugin/churarenPlayerPlugin/churarenPlayerPlugin.ts
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenPlayerPlugin/churarenPlayerPlugin.ts
@@ -219,17 +219,16 @@ export class ChurarenPlayerPlugin extends BaseGamePlugin {
   }
 
   private readonly logPlayerDeathByBoss = (ev: LivingDamageEvent): void => {
-    if (ev.cause instanceof ChurarenEnemyDamageCause) {
-      if (isPlayer(ev.target) && ev.target.isDead) {
-        const deathLog: DeathLog = {
-          victim: ev.target,
-          killer: ev.cause.entityName,
-          cause: ev.cause.entityName,
-          diedTime: new Date(),
-        }
-        this.playerPluginStore.deathLogRenderer.add(deathLog)
-        this.playerPluginStore.deathLogRepository.addDeathLog(deathLog)
+    if (!(ev.cause instanceof ChurarenEnemyDamageCause)) return
+    if (isPlayer(ev.target) && ev.target.isDead) {
+      const deathLog: DeathLog = {
+        victim: ev.target,
+        killer: ev.cause.entityName,
+        cause: ev.cause.entityName,
+        diedTime: new Date(),
       }
+      this.playerPluginStore.deathLogRenderer.add(deathLog)
+      this.playerPluginStore.deathLogRepository.addDeathLog(deathLog)
     }
   }
 

--- a/churaverse-plugins-client/src/churarenPlugin/churarenPlayerPlugin/churarenPlayerPlugin.ts
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenPlayerPlugin/churarenPlayerPlugin.ts
@@ -1,12 +1,12 @@
 import { BaseGamePlugin } from '@churaverse/game-plugin-client/domain/baseGamePlugin'
 import { ItemPluginStore } from '@churaverse/churaren-item-plugin-client/store/defItemPluginStore'
 import { NetworkPluginStore } from '@churaverse/network-plugin-client/store/defNetworkPluginStore'
-import { GRID_SIZE, IMainScene, LivingDamageEvent, Position } from 'churaverse-engine-client'
+import { GRID_SIZE, IMainScene, LivingDamageEvent } from 'churaverse-engine-client'
 import { PlayerPluginStore } from '@churaverse/player-plugin-client/store/defPlayerPluginStore'
 import { PlayerRespawnEvent } from '@churaverse/player-plugin-client/event/playerRespawnEvent'
 import { PlayerWalkEvent } from '@churaverse/player-plugin-client/event/playerWalkEvent'
 import { PlayerNameChangeEvent } from '@churaverse/player-plugin-client/event/playerNameChangeEvent'
-import { CHURAREN_CONSTANTS } from '@churaverse/churaren-core-plugin-client'
+import { CHURAREN_CONSTANTS, ChurarenEnemyDamageCause } from '@churaverse/churaren-core-plugin-client'
 import { ChurarenPlayersStore } from './store/defChurarenPlayersStore'
 import { KeyboardPluginStore } from '@churaverse/keyboard-plugin-client/store/defKeyboardPluginStore'
 import { GhostModeIndicatorUi } from './ui/ghostModeIndicatorUi'
@@ -14,7 +14,7 @@ import { DeathLogRepository } from '@churaverse/player-plugin-client/ui/deathLog
 import { SocketController } from './controller/socketController'
 import { KeyboardController } from './controller/keyboardController'
 import { initChurarenPlayersStore, resetChurarenPlayersStore } from './store/initChurarenPlayersStore'
-import { GRID_WALK_DURATION_MS } from '@churaverse/player-plugin-client/domain/player'
+import { GRID_WALK_DURATION_MS, isPlayer } from '@churaverse/player-plugin-client/domain/player'
 import { InvicibleTimeEvent } from './event/invicibleTimeEvent'
 import { Item } from '@churaverse/churaren-item-plugin-client/domain/item'
 import { materialItemImage } from '@churaverse/churaren-item-plugin-client/domain/itemKind'
@@ -25,6 +25,7 @@ import { initPlayerItemStore, resetPlayerItemStore } from './store/initPlayerIte
 import { DropChurarenItemEvent } from './event/dropChurarenItemEvent'
 import { DropChurarenItemData, DropChurarenItemMessage } from './message/dropChurarenItemMessage'
 import { GamePluginStore } from '@churaverse/game-plugin-client/store/defGamePluginStore'
+import { DeathLog } from '@churaverse/player-plugin-client/ui/deathLog/deathLog'
 
 export class ChurarenPlayerPlugin extends BaseGamePlugin {
   public gameId = CHURAREN_CONSTANTS.GAME_ID
@@ -218,8 +219,18 @@ export class ChurarenPlayerPlugin extends BaseGamePlugin {
   }
 
   private readonly logPlayerDeathByBoss = (ev: LivingDamageEvent): void => {
-    // TODO: プレイヤーがボスによって死亡した時のログを流す
-    //  (churarenBossPluginのChurarenEnemyDamageCauseかどうかを判定する)
+    if (ev.cause instanceof ChurarenEnemyDamageCause) {
+      if (isPlayer(ev.target) && ev.target.isDead) {
+        const deathLog: DeathLog = {
+          victim: ev.target,
+          killer: ev.cause.entityName,
+          cause: ev.cause.entityName,
+          diedTime: new Date(),
+        }
+        this.playerPluginStore.deathLogRenderer.add(deathLog)
+        this.playerPluginStore.deathLogRepository.addDeathLog(deathLog)
+      }
+    }
   }
 
   private readonly onChangePlayerName = (ev: PlayerNameChangeEvent): void => {

--- a/churaverse-plugins-server/src/churarenPlugin/churarenBossPlugin/domain/boss.ts
+++ b/churaverse-plugins-server/src/churarenPlugin/churarenBossPlugin/domain/boss.ts
@@ -1,6 +1,6 @@
-import { ICollidableEntity } from "@churaverse/collision-detection-plugin-server/domain/collisionDetection/collidableEntity/ICollidableEntity"
-import { IRectangle } from "@churaverse/collision-detection-plugin-server/domain/collisionDetection/collidableEntity/IRectangle"
-import { Direction, LivingEntity, Position, Vector } from "churaverse-engine-server"
+import { ICollidableEntity } from '@churaverse/collision-detection-plugin-server/domain/collisionDetection/collidableEntity/ICollidableEntity'
+import { IRectangle } from '@churaverse/collision-detection-plugin-server/domain/collisionDetection/collidableEntity/IRectangle'
+import { Direction, Entity, LivingEntity, Position, Vector } from 'churaverse-engine-server'
 
 export const CHURAREN_BOSS_WALK_DURATION_MS = 1000
 export const CHURAREN_BOSS_SIZE = 150
@@ -62,4 +62,14 @@ export class Boss extends LivingEntity implements ICollidableEntity {
   public stop(): void {
     this._velocity = { x: 0, y: 0 }
   }
+}
+
+/**
+ * 外部プラグインからボスかどうか判定する型ガード関数
+ */
+export function isBoss(entity: Entity): entity is Boss {
+  if (!(entity instanceof LivingEntity)) return false
+  const bossKeys = Object.keys(entity) as Array<keyof Boss>
+  const requiredKeys: Array<keyof Boss> = ['bossId', 'spawnTime', 'power', 'isCollidable']
+  return requiredKeys.every((key) => bossKeys.includes(key))
 }

--- a/churaverse-plugins-server/src/churarenPlugin/churarenPlayerPlugin/churarenPlayerPlugin.ts
+++ b/churaverse-plugins-server/src/churarenPlugin/churarenPlayerPlugin/churarenPlayerPlugin.ts
@@ -6,7 +6,7 @@ import { ItemPluginStore } from '@churaverse/churaren-item-plugin-server/store/d
 import { ChurarenPlayersStore } from './store/defChurarenPlayersStore'
 import { SocketController } from './controller/socketController'
 import { initChurarenPlayersStore, resetChurarenPlayersStore } from './store/initChurarenPlayersStore'
-import { CHURAREN_CONSTANTS } from '@churaverse/churaren-core-plugin-server'
+import { CHURAREN_CONSTANTS, ChurarenEnemyDamageCause } from '@churaverse/churaren-core-plugin-server'
 import { GetChurarenItemEvent } from './event/getChurarenItemEvent'
 import { GetChurarenItemData, GetChurarenItemMessage } from './message/getChurarenItemMessage'
 import { DropChurarenItemEvent } from './event/dropChurarenItemEvent'
@@ -15,6 +15,8 @@ import { initPlayerItemStore, resetPlayerItemStore } from './store/initPlayerIte
 import { InvicibleTimeMessage } from './message/invicibleTimeMessage'
 import { isPlayer, Player } from '@churaverse/player-plugin-server/domain/player'
 import { ChurarenResultEvent } from '@churaverse/churaren-core-plugin-server/event/churarenResultEvent'
+import { ChurarenDamageMessage } from './message/churarenDamageMessage'
+import { isBoss } from '@churaverse/churaren-boss-plugin-server/domain/boss'
 
 export const MAX_ITEMS = 3
 
@@ -78,25 +80,10 @@ export class ChurarenPlayerPlugin extends BaseGamePlugin {
     resetPlayerItemStore(this.store)
   }
 
-  private readonly changeGhostPlayer = (player: Player): void => {
-    if (player === undefined) return
-    this.churarenPlayerStore.ghostModePlayers.set(player.id, player)
-    player.isCollidable = false
-    this.deleteItems(player.id)
-    if (
-      this.churarenPlayerStore.ghostModePlayers.size ===
-      this.gamePluginStore.games.get(this.gameId)?.participantIds.length
-    ) {
-      const updateChurarenUi = new ChurarenResultEvent('gameOver')
-      this.bus.post(updateChurarenUi)
-    }
-  }
-
   private readonly skipDamage = (ev: LivingDamageEvent): void => {
-    // TODO: ちゅられん特有の敵との衝突によるダメージのみ処理を行うように条件を追加
-    if (!this.isActive) return
-    const player = ev.target as Player
-    if (player === undefined) return
+    if (!(ev.cause instanceof ChurarenEnemyDamageCause)) return
+    if (!isPlayer(ev.target)) return
+    const player = ev.target
     if (this.churarenPlayerStore.ghostModePlayers.has(player.id)) return
     if (this.inviciblePlayersList.includes(player.id)) {
       ev.cancel()
@@ -133,12 +120,34 @@ export class ChurarenPlayerPlugin extends BaseGamePlugin {
   }
 
   private readonly onChurarenDamageFromBoss = (ev: LivingDamageEvent): void => {
-    // TODO: ボスから受けたダメージをclientに送信する処理の実装
+    if (!(ev.cause instanceof ChurarenEnemyDamageCause)) return
+    if (isPlayer(ev.target) && isBoss(ev.cause.entity)) {
+      const player = ev.target
+      const damageCause = new ChurarenDamageMessage({
+        targetId: player.id,
+        cause: ev.cause.name,
+        sourceId: ev.cause.entity.id,
+        amount: ev.amount,
+      })
+      this.networkPluginStore.messageSender.send(damageCause)
 
-    if (!isPlayer(ev.target)) return
-    const player = ev.target
-    if (player.isDead) {
-      this.changeGhostPlayer(player)
+      if (player.isDead) {
+        this.changeGhostPlayer(player)
+      }
+    }
+  }
+
+  private changeGhostPlayer(player: Player): void {
+    if (player === undefined) return
+    this.churarenPlayerStore.ghostModePlayers.set(player.id, player)
+    player.isCollidable = false
+    this.deleteItems(player.id)
+    if (
+      this.churarenPlayerStore.ghostModePlayers.size ===
+      this.gamePluginStore.games.get(this.gameId)?.participantIds.length
+    ) {
+      const updateChurarenUi = new ChurarenResultEvent('gameOver')
+      this.bus.post(updateChurarenUi)
     }
   }
 

--- a/churaverse-plugins-server/src/churarenPlugin/churarenPlayerPlugin/package.json
+++ b/churaverse-plugins-server/src/churarenPlugin/churarenPlayerPlugin/package.json
@@ -11,6 +11,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@churaverse/churaren-boss-plugin-server": "file:../churarenBossPlugin",
     "@churaverse/churaren-core-plugin-server": "file:../churarenCorePlugin",
     "@churaverse/churaren-item-plugin-server": "file:../churarenItemPlugin",
     "@churaverse/game-plugin-server": "file:../../gamePlugin",


### PR DESCRIPTION
## 概要
`churarenPlayerPlugin`にボスからのダメージ処理を実装する

チケットへのリンク：https://churadata.backlog.com/view/CV-764

## 変更内容
- `churarenPlayerPlugin`での`ChurarenEnemyDamageCause`によるダメージ処理の実装
-  client側の`churarenBossPlugin`で`CollisionBoss`の死亡ログ作成
- server側の`churarenBossPlugin`で型ガードの実装