### PR TITLE
ゲーム中断・管理者退出時のアラート表示機能追加

### DIFF
--- a/churaverse-plugins-client/src/gamePlugin/domain/coreGamePlugin.ts
+++ b/churaverse-plugins-client/src/gamePlugin/domain/coreGamePlugin.ts
@@ -11,14 +11,14 @@ import { GamePluginStore } from '../store/defGamePluginStore'
 import { BaseGamePlugin } from './baseGamePlugin'
 import { GamePlayerQuitEvent } from '../event/gamePlayerQuitEvent'
 import { GamePlayerQuitMessage } from '../message/gamePlayerQuitMessage'
-import { IGameListItemRenderer } from '../interface/IGameListItemRenderer'
+import { IGameSelectionListItemRenderer } from '../interface/IGameSelectionListItemRenderer'
 
 /**
  * BaseGamePluginを拡張したCoreなゲーム抽象クラス
  */
 export abstract class CoreGamePlugin extends BaseGamePlugin implements IGameInfo {
   public abstract gameId: GameIds
-  protected abstract gameEntryRenderer: IGameListItemRenderer
+  protected abstract gameEntryRenderer: IGameSelectionListItemRenderer
   protected abstract gameName: string
   private _isActive: boolean = false
   private _gameOwnerId?: string

--- a/churaverse-plugins-client/src/gamePlugin/gameExitAlerConfirmtManager.ts
+++ b/churaverse-plugins-client/src/gamePlugin/gameExitAlerConfirmtManager.ts
@@ -1,0 +1,41 @@
+import { GameIds } from './interface/gameIds'
+import { IGameExitAlertConfirm } from './interface/IGameExitAlertConfirm'
+import { IGameExitAlertConfirmManager } from './interface/IGameExitAlertConfirmManager'
+
+export class GameExitAlertConfirmManager implements IGameExitAlertConfirmManager {
+  private readonly gameExitAlerts = new Map<GameIds, IGameExitAlertConfirm>()
+
+  public add(name: GameIds, alert: IGameExitAlertConfirm): void {
+    this.gameExitAlerts.set(name, alert)
+  }
+
+  public showAlert(gameId: GameIds, message?: string): boolean {
+    const alert = this.gameExitAlerts.get(gameId)
+    if (alert === undefined) {
+      // フォールバック: window.confirm を直接使用
+      try {
+        // eslint-disable-next-line no-alert
+        return window.confirm(message ?? 'このゲームを中止して退出しますか？')
+      } catch {
+        return false
+      }
+    }
+
+    try {
+      return alert.show(message)
+    } catch {
+      return false
+    }
+  }
+
+  public closeAlert(): void {
+    // すべての登録済みアラートに対し close を呼ぶ（confirm 実装は副作用なし）
+    for (const a of this.gameExitAlerts.values()) {
+      try {
+        a.close()
+      } catch {
+        // ignore
+      }
+    }
+  }
+}

--- a/churaverse-plugins-client/src/gamePlugin/interface/IGameExitAlertConfirm.ts
+++ b/churaverse-plugins-client/src/gamePlugin/interface/IGameExitAlertConfirm.ts
@@ -1,0 +1,4 @@
+export interface IGameExitAlertConfirm {
+  show: (message?: string) => boolean
+  close: () => void
+}

--- a/churaverse-plugins-client/src/gamePlugin/interface/IGameExitAlertConfirmManager.ts
+++ b/churaverse-plugins-client/src/gamePlugin/interface/IGameExitAlertConfirmManager.ts
@@ -1,0 +1,8 @@
+import { GameIds } from './gameIds'
+import { IGameExitAlertConfirm } from './IGameExitAlertConfirm'
+
+export interface IGameExitAlertConfirmManager {
+  add: (gameId: GameIds, alert: IGameExitAlertConfirm) => void
+  showAlert: (gameId: GameIds, message?: string) => boolean
+  closeAlert: () => void
+}

--- a/churaverse-plugins-client/src/gamePlugin/store/defGamePluginStore.ts
+++ b/churaverse-plugins-client/src/gamePlugin/store/defGamePluginStore.ts
@@ -3,7 +3,7 @@ import { IGameLogRenderer } from '../interface/IGameLogRenderer'
 import { IGameInfoRepository } from '../interface/IGameInfoRepository'
 import { IGameSelectionListContainer } from '../interface/IGameSelectionListContainer'
 import { IGameDescriptionDialogManager } from '../interface/IGameDescriptionDialogManager'
-
+import { IGameExitAlertConfirmManager } from '../interface/IGameExitAlertConfirmManager'
 declare module 'churaverse-engine-client' {
   export interface StoreInMain {
     gamePlugin: GamePluginStore
@@ -16,6 +16,7 @@ export interface GamePluginStore {
   readonly gameLogRenderer: IGameLogRenderer
   readonly gameSelectionListContainer: IGameSelectionListContainer
   readonly gameDescriptionDialogManager: IGameDescriptionDialogManager
+  readonly gameExitAlertConfirmManager: IGameExitAlertConfirmManager
 }
 
 export interface GameInfoStore {

--- a/churaverse-plugins-client/src/gamePlugin/store/initGamePluginStore.ts
+++ b/churaverse-plugins-client/src/gamePlugin/store/initGamePluginStore.ts
@@ -3,6 +3,7 @@ import { GameInfoStore, GamePluginStore } from './defGamePluginStore'
 import { GameLogRenderer } from '../ui/logRenderer/gameLogRenderer'
 import { GameUiRegister } from '../gameUiRegister'
 import { GameUiManager } from '../gameUiManager'
+import { GameExitAlertConfirmManager } from '../gameExitAlerConfirmtManager'
 import { GameInfoRepository } from '../repository/gameInfoRepository'
 import { GameSelectionListContainer } from '../ui/gameList/gameSelectionListContainer'
 import { GameDescriptionDialogManager } from '../gameDescriptionDialogManager'
@@ -13,8 +14,8 @@ export function initGamePluginStore(store: Store<IMainScene>, gameUiRegister: Ga
     gameLogRenderer: new GameLogRenderer(store),
     gameSelectionListContainer: new GameSelectionListContainer(),
     gameDescriptionDialogManager: new GameDescriptionDialogManager(),
+    gameExitAlertConfirmManager: new GameExitAlertConfirmManager(),
   }
-
   const gameInfoStore: GameInfoStore = { games: new GameInfoRepository() }
 
   store.setInit('gamePlugin', pluginStore)

--- a/churaverse-plugins-client/src/gamePlugin/ui/exit/gameExitAlertManager.ts
+++ b/churaverse-plugins-client/src/gamePlugin/ui/exit/gameExitAlertManager.ts
@@ -1,0 +1,19 @@
+import { IGameExitAlertConfirm } from '../../interface/IGameExitAlertConfirm'
+
+/**
+ * window.confirm を使用した標準的な退出確認ダイアログ
+ */
+export class ExitAlert implements IGameExitAlertConfirm {
+  public show(message?: string): boolean {
+    try {
+      // eslint-disable-next-line no-alert
+      return window.confirm(message ?? 'このゲームを中止して退出しますか？')
+    } catch {
+      return false
+    }
+  }
+
+  public close(): void {
+    // window.confirm は自動的に閉じるため、特に何もしない
+  }
+}

--- a/churaverse-plugins-client/src/gamePlugin/ui/gameList/gameSelectionListItemRenderer.ts
+++ b/churaverse-plugins-client/src/gamePlugin/ui/gameList/gameSelectionListItemRenderer.ts
@@ -44,7 +44,7 @@ export abstract class GameSelectionListItemRenderer implements IGameSelectionLis
   private currentButtonState: GameState
 
   public constructor(
-    private readonly store: Store<IMainScene>,
+    protected readonly store: Store<IMainScene>,
     private readonly gameDetailManager: IGameDescriptionDialogManager,
     private readonly props: GameSelectionListItemProps
   ) {
@@ -152,7 +152,16 @@ export abstract class GameSelectionListItemRenderer implements IGameSelectionLis
     this.networkPlugin.messageSender.send(gameStartMessage)
   }
 
-  private sendGameAbortMessage(): void {
+  protected sendGameAbortMessage(): void {
+    // 中止前に確認ダイアログを表示
+    const gamePluginStore = this.store.of('gamePlugin')
+    const ok = gamePluginStore.gameExitAlertConfirmManager.showAlert(this.props.gameId)
+    if (!ok) {
+      // ユーザーがキャンセルした場合は送信しない
+      return
+    }
+
+    // ユーザーがOKした場合のみ中止メッセージを送信
     const gameAbortMessage = new RequestGameAbortMessage({
       gameId: this.props.gameId,
       playerId: this.store.of('playerPlugin').ownPlayerId,

--- a/churaverse-plugins-client/src/synchroBreakPlugin/store/defSynchroBreakPluginStore.ts
+++ b/churaverse-plugins-client/src/synchroBreakPlugin/store/defSynchroBreakPluginStore.ts
@@ -6,6 +6,7 @@ export interface SynchroBreakPluginStore {
   readonly synchroBreakIcons: Map<string, PlayerNyokkiStatusIcon>
   readonly playersCoinRepository: IPlayersCoinRepository
   readonly nyokkiLogTextCreator: INyokkiLogTextCreator
+  exitConfirmMessage?: string
   timeLimit: number | undefined
   gameTurn: number | undefined
 }

--- a/churaverse-plugins-client/src/synchroBreakPlugin/store/synchroBreakPluginStoreManager.ts
+++ b/churaverse-plugins-client/src/synchroBreakPlugin/store/synchroBreakPluginStoreManager.ts
@@ -12,6 +12,7 @@ export function initSynchroBreakPluginStore(store: Store<IMainScene>): void {
     synchroBreakIcons: new Map<string, PlayerNyokkiStatusIcon>(),
     playersCoinRepository: new PlayersCoinRepository(),
     nyokkiLogTextCreator: new NyokkiLogTextCreator(store),
+    exitConfirmMessage: 'シンクロブレイクを終わる？',
     timeLimit: undefined,
     gameTurn: undefined,
   }

--- a/churaverse-plugins-client/src/synchroBreakPlugin/store/synchroBreakPluginStoreManager.ts
+++ b/churaverse-plugins-client/src/synchroBreakPlugin/store/synchroBreakPluginStoreManager.ts
@@ -12,7 +12,7 @@ export function initSynchroBreakPluginStore(store: Store<IMainScene>): void {
     synchroBreakIcons: new Map<string, PlayerNyokkiStatusIcon>(),
     playersCoinRepository: new PlayersCoinRepository(),
     nyokkiLogTextCreator: new NyokkiLogTextCreator(store),
-    exitConfirmMessage: 'シンクロブレイクを終わる？',
+    exitConfirmMessage: '中止すると、みんなのプレイがここで終わります。中止しますか？',
     timeLimit: undefined,
     gameTurn: undefined,
   }

--- a/churaverse-plugins-client/src/synchroBreakPlugin/synchroBreakPlugin.ts
+++ b/churaverse-plugins-client/src/synchroBreakPlugin/synchroBreakPlugin.ts
@@ -27,6 +27,7 @@ import { NyokkiStatus } from './type/nyokkiStatus'
 import { IRankingBoard } from './interface/IRankingBoard'
 import { IGameSelectionListItemRenderer } from '@churaverse/game-plugin-client/interface/IGameSelectionListItemRenderer'
 import { SynchroBreakListItemRenderer } from './ui/startWindow/synchroBreakListItemRenderer'
+import { ExitAlert } from '@churaverse/game-plugin-client/ui/exit/gameExitAlertManager'
 
 export class SynchroBreakPlugin extends CoreGamePlugin {
   public readonly gameId = 'synchroBreak'
@@ -109,7 +110,7 @@ export class SynchroBreakPlugin extends CoreGamePlugin {
     )
 
     // 退出アラートを SynchroBreak 用に登録（新しい Confirm Manager 経由）
-    // this.gamePluginStore.gameExitAlertConfirmManager.add(this.gameId, new ExitAlert())
+    this.gamePluginStore.gameExitAlertConfirmManager.add(this.gameId, new ExitAlert())
   }
 
   /**
@@ -155,10 +156,6 @@ export class SynchroBreakPlugin extends CoreGamePlugin {
   protected handleGameTermination(): void {
     resetSynchroBreakPluginStore(this.store)
     this.socketController.unregisterMessageListener()
-    //  退出アラートを表示（manager 経由）
-    const message = this.synchroBreakPluginStore.exitConfirmMessage
-    const ok = this.gamePluginStore.gameExitAlertConfirmManager.showAlert(this.gameId, message)
-    if (!ok) return
 
     if (!this.isOwnPlayerMidwayParticipant) {
       resetSynchroBreakPluginStore(this.store)

--- a/churaverse-plugins-client/src/synchroBreakPlugin/synchroBreakPlugin.ts
+++ b/churaverse-plugins-client/src/synchroBreakPlugin/synchroBreakPlugin.ts
@@ -26,7 +26,7 @@ import { SynchroBreakTurnStartEvent } from './event/synchroBerakTurnStartEvent'
 import { UpdatePlayersCoinEvent } from './event/updatePlayersCoinEvent'
 import { NyokkiStatus } from './type/nyokkiStatus'
 import { IRankingBoard } from './interface/IRankingBoard'
-import { IGameListItemRenderer } from '@churaverse/game-plugin-client/interface/IGameListItemRenderer'
+import { IGameSelectionListItemRenderer } from '@churaverse/game-plugin-client/interface/IGameSelectionListItemRenderer'
 import { SynchroBreakListItemRenderer } from './ui/startWindow/synchroBreakListItemRenderer'
 
 export class SynchroBreakPlugin extends CoreGamePlugin {
@@ -34,7 +34,7 @@ export class SynchroBreakPlugin extends CoreGamePlugin {
   protected readonly gameName = 'シンクロブレイク'
   private nyokkiActionMessage: string | undefined = undefined
   private ownNyokkiSatatus: NyokkiStatus = 'yet'
-  protected gameEntryRenderer!: IGameListItemRenderer
+  protected gameEntryRenderer!: IGameSelectionListItemRenderer
 
   private synchroBreakPluginStore!: SynchroBreakPluginStore
   private playerPluginStore!: PlayerPluginStore

--- a/churaverse-plugins-client/src/synchroBreakPlugin/ui/resultScreen/resultScreen.ts
+++ b/churaverse-plugins-client/src/synchroBreakPlugin/ui/resultScreen/resultScreen.ts
@@ -78,6 +78,19 @@ export class ResultScreen implements ISynchroBreakResultScreen {
     this.element.appendChild(exitButton)
     exitButton.addEventListener('click', () => {
       const playerId = this.store.of('playerPlugin').ownPlayerId
+      
+      // 退出前に確認ダイアログを表示
+      const gamePluginStore = this.store.of('gamePlugin')
+      const synchroBreakStore = this.store.of('synchroBreakPlugin')
+      const message = synchroBreakStore.exitConfirmMessage
+      
+      const ok = gamePluginStore.gameExitAlertConfirmManager.showAlert(this.gameId, message)
+      if (!ok) {
+        // ユーザーがキャンセルした場合は何もしない
+        return
+      }
+      
+      // ユーザーがOKした場合のみ退出処理を実行
       this.eventBus.post(new GamePlayerQuitEvent(this.gameId, playerId))
       this.remove()
     })

--- a/churaverse-plugins-client/src/synchroBreakPlugin/ui/startWindow/synchroBreakListItemRenderer.ts
+++ b/churaverse-plugins-client/src/synchroBreakPlugin/ui/startWindow/synchroBreakListItemRenderer.ts
@@ -2,6 +2,7 @@ import { IMainScene, Store } from 'churaverse-engine-client'
 import { IGameDescriptionDialogManager } from '@churaverse/game-plugin-client/interface/IGameDescriptionDialogManager'
 import { IGameSelectionListContainer } from '@churaverse/game-plugin-client/interface/IGameSelectionListContainer'
 import { GameSelectionListItemRenderer } from '@churaverse/game-plugin-client/ui/gameList/gameSelectionListItemRenderer'
+import { RequestGameAbortMessage } from '@churaverse/game-plugin-client/message/gameAbortMessage'
 
 import SYNCHRO_BREAK_ICON_PATH from '../../assets/synchroBreakIcon.png'
 
@@ -19,5 +20,21 @@ export class SynchroBreakListItemRenderer extends GameSelectionListItemRenderer 
       order: 10,
     })
     gameListContainer.addGame(this)
+  }
+
+  protected override sendGameAbortMessage(): void {
+    // SynchroBreak 固有の確認メッセージ（store 初期化済前提）
+    const gamePluginStore = this.store.of('gamePlugin')
+    const synchro = this.store.of('synchroBreakPlugin') as { exitConfirmMessage?: string }
+    const message = synchro.exitConfirmMessage
+    const ok = gamePluginStore.gameExitAlertConfirmManager.showAlert('synchroBreak', message)
+    if (!ok) return
+
+    // 親の送信ロジック相当（重複実装：基底は private → override 部分で再実装）
+    const abortMsg = new RequestGameAbortMessage({
+      gameId: 'synchroBreak',
+      playerId: this.store.of('playerPlugin').ownPlayerId,
+    })
+    this.store.of('networkPlugin').messageSender.send(abortMsg)
   }
 }


### PR DESCRIPTION
[https://churadata.backlog.com/view/CV-799](url)
実装内容
・gamePluginのstoreにAlertShowメソッドを作成
他のゲームの基盤プラグイン（例：synchroBreak,churaenPlugin）のゲーム中断の際に、個別のアラートを表示できる機能の追加