### PR TITLE
networkPluginでのオブジェクトのコピー方式の変更

### DIFF
--- a/churaverse-plugins-server/src/networkPlugin/package.json
+++ b/churaverse-plugins-server/src/networkPlugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@churaverse/network-plugin-server",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",

--- a/churaverse-plugins-server/src/networkPlugin/queue/receiveQueue.ts
+++ b/churaverse-plugins-server/src/networkPlugin/queue/receiveQueue.ts
@@ -28,9 +28,9 @@ export class ReceiveQueue<Scene extends Scenes> implements IReceiveQueue<Scene> 
   public popPacket(): Packet<Scene> {
     let poppedPacket: Packet<Scene> = []
     void this.lock.acquire(RECEIVE_QUEUE_ASYNC_LOCK_KEY, () => {
-      // 文字列化してdeep copyするこの方法ではシリアライズ可能なオブジェクトのみコピー可能
+      // この方法ではシリアライズ可能なオブジェクトのみコピー可能
       // socket.ioで通信できるのもシリアライズ可能なオブジェクトのみなのでこの方法でdeep copyしている
-      poppedPacket = JSON.parse(JSON.stringify(this.packets)) as Packet<Scene>
+      poppedPacket = structuredClone(this.packets)
       this.packets.length = 0
     })
 

--- a/churaverse-plugins-server/src/networkPlugin/queue/transmitQueue.ts
+++ b/churaverse-plugins-server/src/networkPlugin/queue/transmitQueue.ts
@@ -144,9 +144,10 @@ export class TransmitQueue<Scene extends Scenes> implements ITransmitQueue<Scene
    * 排他制御は行わないので外部からは使用しない
    */
   private popPacketAtWithoutLock(playerId: string): Packet<Scene> {
-    // 文字列化してdeep copyするこの方法ではシリアライズ可能なオブジェクトのみコピー可能
+    // この方法ではシリアライズ可能なオブジェクトのみコピー可能
     // socket.ioで通信できるのもシリアライズ可能なオブジェクトのみなのでこの方法でdeep copyしている
-    const poppedPacket = JSON.parse(JSON.stringify(this.packets.get(playerId))) as Packet<Scene>
+    const packet = this.packets.get(playerId)
+    const poppedPacket = packet !== undefined ? structuredClone(packet) : []
     // 中身を空に
     this.packets.set(playerId, [])
     return poppedPacket


### PR DESCRIPTION
networkPluginの内部処理で行われているオブジェクトのディープコピーついて、JSON化を用いて行う方法ではオブジェクトが大きい場合にパフォーマンス上の問題があるため別の方法に変更する

変更先: structuredClone (node.js ではv17から対応)

マージ後に npmリポジトリの更新を行う