### PR TITLE
再接続処理の実装

### DIFF
--- a/churaverse-plugins-client/src/networkPlugin/event/networkConnectEvent.ts
+++ b/churaverse-plugins-client/src/networkPlugin/event/networkConnectEvent.ts
@@ -1,0 +1,13 @@
+import { CVEvent, IMainScene } from 'churaverse-engine-client'
+
+export class NetworkConnectEvent extends CVEvent<IMainScene> {
+  public constructor() {
+    super('networkConnect', false)
+  }
+}
+
+declare module 'churaverse-engine-client' {
+  export interface CVMainEventMap {
+    networkConnect: NetworkConnectEvent
+  }
+}

--- a/churaverse-plugins-client/src/networkPlugin/messageManager.ts
+++ b/churaverse-plugins-client/src/networkPlugin/messageManager.ts
@@ -1,4 +1,4 @@
-import { Scenes } from 'churaverse-engine-client'
+import { IEventBus, Scenes } from 'churaverse-engine-client'
 import { MessageBuffer } from './buffer'
 import { NotExistsBufferError } from './errors/notExistsBufferError'
 import { IMessageConstructor } from './interface/IMessage'
@@ -31,7 +31,6 @@ export class MessageManager<Scene extends Scenes>
   private lastSendTime = Date.now()
 
   public constructor(
-    private readonly senderId: string,
     /**
      * パケット化する時間幅(ms).
      * 最初にbufferに格納されてからpacketIntervalだけ待機し, その間にbufferに追加されたデータをまとめて送信する
@@ -85,7 +84,7 @@ export class MessageManager<Scene extends Scenes>
    * 全てのbufferのMessageをパケット化してサーバーに送信する
    */
   public sendPacket(): void {
-    this.messageManagerHelper.sendPacket(this.senderId, this.messageBuffers)
+    this.messageManagerHelper.sendPacket(this.socketId, this.messageBuffers)
     this.lastSendTime = Date.now()
     this.anyBufferHasData = false
   }
@@ -94,7 +93,7 @@ export class MessageManager<Scene extends Scenes>
    * パケットを送信する必要がある場合Trueを返す
    */
   public shouldSendPacket(now: number = Date.now()): boolean {
-    return this.anyBufferHasData && this.isTimeExceedingLastSendPacket(now)
+    return this.anyBufferHasData && this.isTimeExceedingLastSendPacket(now) && this.messageManagerHelper.connected
   }
 
   /**
@@ -108,5 +107,9 @@ export class MessageManager<Scene extends Scenes>
 
   public get socketId(): string {
     return this.messageManagerHelper.socketId
+  }
+
+  public socketEventToBusEvent(bus: IEventBus<Scenes>): void {
+    this.messageManagerHelper.socketEventToBusEvent(bus)
   }
 }

--- a/churaverse-plugins-client/src/networkPlugin/messageManagerHelper.ts
+++ b/churaverse-plugins-client/src/networkPlugin/messageManagerHelper.ts
@@ -1,5 +1,5 @@
 import { MessageType } from './message/messages'
-import { Scenes } from 'churaverse-engine-client'
+import { IEventBus, Scenes } from 'churaverse-engine-client'
 import { MessageBuffer } from './buffer'
 import { Socket } from './socket/socket'
 import { Packet, SendMessage } from './socket/packet'
@@ -82,5 +82,13 @@ export class MessageManagerHelper<Scene extends Scenes> {
 
   public get socketId(): string {
     return this.socket.socketId
+  }
+
+  public get connected(): boolean {
+    return this.socket.connected
+  }
+
+  public socketEventToBusEvent(eventBus: IEventBus<Scenes>): void {
+    this.socket.socketEventToBusEvent(eventBus)
   }
 }

--- a/churaverse-plugins-client/src/networkPlugin/networkPlugin.ts
+++ b/churaverse-plugins-client/src/networkPlugin/networkPlugin.ts
@@ -1,15 +1,25 @@
-import { BasePlugin, Scenes, EVENT_PRIORITY, PhaserSceneInit, InitEvent, CVEvent } from 'churaverse-engine-client'
+import {
+  BasePlugin,
+  Scenes,
+  EVENT_PRIORITY,
+  PhaserSceneInit,
+  InitEvent,
+  CVEvent,
+  IMainScene,
+  PartialWritable,
+} from 'churaverse-engine-client'
 import { Scene } from 'phaser'
 import { initNetworkPluginStore } from './store/initNetworkPluginStore'
 import { PriorDataRequestMessage } from './message/priorDataMessage'
 import { RegisterMessageListenerEvent } from './event/registerMessageListenerEvent'
 import { RegisterMessageEvent } from './event/registerMessageEvent'
 import { MessageManager } from './messageManager'
-import { Socket } from './socket/socket'
 import { MessageManagerUndefinedError } from './errors/messageManagerUndefinedError'
 import { SocketController } from './controller/socketController'
 
 import { NetworkPluginStore } from './store/defNetworkPluginStore'
+
+type WritableSocketId = PartialWritable<NetworkPluginStore<IMainScene>, 'socketId'>
 
 export class NetworkPlugin extends BasePlugin<Scenes> {
   private scene?: Scene
@@ -25,6 +35,8 @@ export class NetworkPlugin extends BasePlugin<Scenes> {
     this.bus.subscribeEvent('registerMessage', socketController.registerMessage.bind(socketController))
 
     this.bus.subscribeEvent('update', this.update.bind(this))
+
+    this.bus.subscribeEvent('networkConnect', this.onNetworkConnect.bind(this), EVENT_PRIORITY.HIGH)
   }
 
   private phaserSceneInit(ev: PhaserSceneInit): void {
@@ -32,9 +44,8 @@ export class NetworkPlugin extends BasePlugin<Scenes> {
   }
 
   private init(ev: InitEvent): void {
-    const socket = Socket.build()
-    socket.socketEventToBusEvent(this.bus)
-    this.messageManager = new MessageManager(socket.socketId)
+    this.messageManager = new MessageManager()
+    this.messageManager.socketEventToBusEvent(this.bus)
     initNetworkPluginStore(this.store, this.scene, this.messageManager, this.messageManager.socketId)
   }
 
@@ -59,5 +70,12 @@ export class NetworkPlugin extends BasePlugin<Scenes> {
     if (this.messageManager.shouldSendPacket()) {
       this.messageManager.sendPacket()
     }
+  }
+
+  private onNetworkConnect(): void {
+    if (!(this.scene instanceof IMainScene)) return
+    const networkPluginStore = this.store.of('networkPlugin') as WritableSocketId
+    networkPluginStore.socketId = this.messageManager?.socketId ?? ''
+    this.requestPriorData()
   }
 }

--- a/churaverse-plugins-client/src/networkPlugin/package.json
+++ b/churaverse-plugins-client/src/networkPlugin/package.json
@@ -34,8 +34,8 @@
   "types": "./dist/types/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "churaverse-engine-client": "file:../../../../churaverse-engine/churaverse-engine-client",
     "phaser": "^3.80.1",
-    "socket.io-client": "^4.7.4"
+    "socket.io-client": "^4.7.4",
+    "churaverse-engine-client": "~0.1.1"
   }
 }

--- a/churaverse-plugins-client/src/networkPlugin/package.json
+++ b/churaverse-plugins-client/src/networkPlugin/package.json
@@ -36,6 +36,6 @@
   "dependencies": {
     "phaser": "^3.80.1",
     "socket.io-client": "^4.7.4",
-    "churaverse-engine-client": "~0.1.1"
+    "churaverse-engine-client": "~0.1.2"
   }
 }

--- a/churaverse-plugins-client/src/networkPlugin/package.json
+++ b/churaverse-plugins-client/src/networkPlugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@churaverse/network-plugin-client",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "build": "tsc",

--- a/churaverse-plugins-client/src/networkPlugin/package.json
+++ b/churaverse-plugins-client/src/networkPlugin/package.json
@@ -34,8 +34,8 @@
   "types": "./dist/types/index.d.ts",
   "license": "MIT",
   "dependencies": {
+    "churaverse-engine-client": "file:../../../../churaverse-engine/churaverse-engine-client",
     "phaser": "^3.80.1",
-    "socket.io-client": "^4.7.4",
-    "churaverse-engine-client": "~0.1.1"
+    "socket.io-client": "^4.7.4"
   }
 }

--- a/churaverse-plugins-client/src/networkPlugin/socket/socket.ts
+++ b/churaverse-plugins-client/src/networkPlugin/socket/socket.ts
@@ -1,6 +1,7 @@
 import { io, Socket as ioSocket } from 'socket.io-client'
 import { Packet } from './packet'
 import { IEventBus, Scenes } from 'churaverse-engine-client'
+import { NetworkConnectEvent } from '../event/networkConnectEvent'
 import { NetworkDisconnectEvent } from '../event/networkDisconnectEvent'
 
 const SEND_PACKET_TO_SERVER = 'sendPacketToServer'
@@ -65,14 +66,22 @@ export class Socket<Scene extends Scenes> {
     return this.iosocket.id ?? ''
   }
 
+  public get connected(): boolean {
+    return this.iosocket.connected
+  }
+
   public get ioSocket(): ioSocket {
     // TODO: 旧Socketクラスが置き換わり次第, 関数削除
     return this.iosocket
   }
 
-  public socketEventToBusEvent(bus: IEventBus<Scenes>): void {
+  public socketEventToBusEvent(eventBus: IEventBus<Scenes>): void {
+    this.iosocket.on('connect', () => {
+      eventBus.post(new NetworkConnectEvent())
+    })
+
     this.iosocket.on('disconnect', () => {
-      bus.post(new NetworkDisconnectEvent())
+      eventBus.post(new NetworkDisconnectEvent())
     })
   }
 }

--- a/churaverse-plugins-client/src/playerPlugin/package.json
+++ b/churaverse-plugins-client/src/playerPlugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@churaverse/player-plugin-client",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "build": "tsc && bash copyAssetsToDist.sh",

--- a/churaverse-plugins-client/src/playerPlugin/package.json
+++ b/churaverse-plugins-client/src/playerPlugin/package.json
@@ -39,11 +39,11 @@
     "@churaverse/debug-screen-plugin-client": "~0.1.0",
     "@churaverse/keyboard-plugin-client": "~0.1.0",
     "@churaverse/map-plugin-client": "~0.1.0",
-    "@churaverse/network-plugin-client": "~0.1.2",
+    "@churaverse/network-plugin-client": "~0.1.3",
     "@churaverse/title-plugin-client": "~0.1.0",
     "@churaverse/transition-plugin-client": "~0.1.0",
     "@churaverse/voice-chat-plugin-client": "~0.1.0",
-    "churaverse-engine-client": "~0.1.1",
+    "churaverse-engine-client": "~0.1.2",
     "phaser": "^3.80.1"
   }
 }

--- a/churaverse-plugins-client/src/playerPlugin/package.json
+++ b/churaverse-plugins-client/src/playerPlugin/package.json
@@ -39,11 +39,11 @@
     "@churaverse/debug-screen-plugin-client": "~0.1.0",
     "@churaverse/keyboard-plugin-client": "~0.1.0",
     "@churaverse/map-plugin-client": "~0.1.0",
-    "@churaverse/network-plugin-client": "file:../networkPlugin",
+    "@churaverse/network-plugin-client": "~0.1.2",
     "@churaverse/title-plugin-client": "~0.1.0",
     "@churaverse/transition-plugin-client": "~0.1.0",
     "@churaverse/voice-chat-plugin-client": "~0.1.0",
-    "churaverse-engine-client": "file:../../../../churaverse-engine/churaverse-engine-client",
+    "churaverse-engine-client": "~0.1.1",
     "phaser": "^3.80.1"
   }
 }

--- a/churaverse-plugins-client/src/playerPlugin/package.json
+++ b/churaverse-plugins-client/src/playerPlugin/package.json
@@ -39,11 +39,11 @@
     "@churaverse/debug-screen-plugin-client": "~0.1.0",
     "@churaverse/keyboard-plugin-client": "~0.1.0",
     "@churaverse/map-plugin-client": "~0.1.0",
-    "@churaverse/network-plugin-client": "~0.1.2",
+    "@churaverse/network-plugin-client": "file:../networkPlugin",
     "@churaverse/title-plugin-client": "~0.1.0",
     "@churaverse/transition-plugin-client": "~0.1.0",
     "@churaverse/voice-chat-plugin-client": "~0.1.0",
-    "churaverse-engine-client": "~0.1.1",
+    "churaverse-engine-client": "file:../../../../churaverse-engine/churaverse-engine-client",
     "phaser": "^3.80.1"
   }
 }

--- a/churaverse-plugins-client/src/playerPlugin/playerPlugin.ts
+++ b/churaverse-plugins-client/src/playerPlugin/playerPlugin.ts
@@ -17,6 +17,7 @@ import {
   DamageCauseType,
   vectorToName,
   Vector,
+  PartialWritable,
 } from 'churaverse-engine-client'
 import { PlayerSetupInfoWriter } from './interface/playerSetupInfoWriter'
 import { CookieStore } from '@churaverse/data-persistence-plugin-client/cookieStore'
@@ -69,9 +70,12 @@ import { initPlayerPluginStore } from './store/initPlayerPluginStore'
 import { DeathLog } from './ui/deathLog/deathLog'
 import { DeathLogRepository } from './ui/deathLog/deathLogRepository'
 import { JoinLeaveLogRenderer } from './ui/joinLeaveLogRenderer/joinLeaveLogRenderer'
-import { setupPlayerUi } from './ui/setupPlayerUi'
+import { PlayerUi } from './ui/setupPlayerUi'
 import { Sendable } from '@churaverse/network-plugin-client/types/sendable'
+import '@churaverse/network-plugin-client/event/networkConnectEvent'
 import '@churaverse/network-plugin-client/event/networkDisconnectEvent'
+
+type WritableOwnPlayerId = PartialWritable<PlayerPluginStore, 'ownPlayerId'>
 
 export class PlayerPlugin extends BasePlugin<IMainScene> {
   private rendererFactory?: PlayerRendererFactory
@@ -93,6 +97,7 @@ export class PlayerPlugin extends BasePlugin<IMainScene> {
   private playerPositionDebugScreen!: IPlayerPositionDebugScreen
   private playerPositionGridDebugScreen!: IPlayerPositionDebugScreen
   private playerRoleDebugScreen!: IPlayerRoleDebugScreen
+  private playerUi!: PlayerUi
 
   public listenEvent(): void {
     this.bus.subscribeEvent('phaserSceneInit', this.phaserSceneInit.bind(this))
@@ -126,7 +131,7 @@ export class PlayerPlugin extends BasePlugin<IMainScene> {
     this.bus.subscribeEvent('playerDie', this.onDiePlayer.bind(this))
     this.bus.subscribeEvent('playerRespawn', this.onRespawnPlayer.bind(this))
     this.bus.subscribeEvent('dumpDebugData', this.dumpDebugData.bind(this))
-
+    this.bus.subscribeEvent('networkConnect', this.onNetworkConnect.bind(this))
     this.bus.subscribeEvent('networkDisconnect', this.onNetworkDisconnect.bind(this))
   }
 
@@ -150,8 +155,8 @@ export class PlayerPlugin extends BasePlugin<IMainScene> {
   }
 
   private start(ev: StartEvent): void {
-    const joinLeaveLogRenderer = setupPlayerUi(this.store, this.bus)
-    this.joinLeaveLogRenderer = joinLeaveLogRenderer
+    this.playerUi = new PlayerUi(this.store, this.bus)
+    this.joinLeaveLogRenderer = this.playerUi.setupJoinLeaveLogRenderer()
     this.createOwnPlayer()
     this.setupDebugScreen()
   }
@@ -529,7 +534,60 @@ export class PlayerPlugin extends BasePlugin<IMainScene> {
     ev.dataDumper.dump('playerRole', ownPlayer.role)
   }
 
+  private onNetworkConnect(): void {
+    const prevOwnPlayer = this.playerPluginStore.players.get(this.playerPluginStore.ownPlayerId)
+    if (prevOwnPlayer === undefined) return
+    this.playerPluginStore.players.delete(prevOwnPlayer.id)
+    this.playerPluginStore.playerRenderers.get(prevOwnPlayer.id)?.destroy()
+    this.playerPluginStore.playerRenderers.delete(prevOwnPlayer.id)
+
+    const playerPluginStore = this.playerPluginStore as WritableOwnPlayerId
+    playerPluginStore.ownPlayerId = this.networkStore.socketId
+    this.playerUi.updatePlayerId(this.playerPluginStore.ownPlayerId)
+
+    const data: PlayerJoinData = {
+      hp: prevOwnPlayer.hp,
+      position: prevOwnPlayer.position.toVector() as Vector & Sendable,
+      direction: prevOwnPlayer.direction,
+      playerId: this.playerPluginStore.ownPlayerId,
+      heroColor: prevOwnPlayer.color,
+      heroName: prevOwnPlayer.name,
+      role: prevOwnPlayer.role,
+      spawnTime: prevOwnPlayer.spawnTime,
+    }
+
+    this.networkStore.messageSender.send(new PlayerJoinMessage(data))
+    const player = new Player(
+      this.playerPluginStore.ownPlayerId,
+      prevOwnPlayer.position,
+      prevOwnPlayer.direction,
+      prevOwnPlayer.name,
+      prevOwnPlayer.color,
+      prevOwnPlayer.hp,
+      prevOwnPlayer.role,
+      prevOwnPlayer.spawnTime
+    )
+    this.bus.post(new EntitySpawnEvent(player))
+    const playerRenderer = this.playerPluginStore.playerRenderers.get(this.playerPluginStore.ownPlayerId)
+    if (playerRenderer === undefined) throw new PlayerRendererNotFoundError(this.playerPluginStore.ownPlayerId)
+    this.uiStore.focusTargetRepository.addFocusTarget(playerRenderer)
+    playerRenderer.focus()
+    this.utilStore.focusedRenderer = playerRenderer
+  }
+
   private onNetworkDisconnect(): void {
-    this.transitionPluginStore.transitionManager.transitionTo('TitleScene')
+    const player = this.playerPluginStore.players.get(this.playerPluginStore.ownPlayerId)
+    if (player === undefined) return
+    const renderer = this.playerPluginStore.playerRenderers.get(this.playerPluginStore.ownPlayerId)
+    if (renderer === undefined) return
+    this.playerPluginStore.playerRenderers.forEach((renderer, id) => {
+      if (id === this.playerPluginStore.ownPlayerId) return
+      renderer.destroy()
+    })
+    this.playerPluginStore.players.getAllId().forEach((id) => {
+      if (id === this.playerPluginStore.ownPlayerId) return
+      this.playerPluginStore.players.delete(id)
+      this.playerPluginStore.playerRenderers.delete(id)
+    })
   }
 }

--- a/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/playerColorButtons.ts
+++ b/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/playerColorButtons.ts
@@ -12,7 +12,7 @@ export const PLAYER_COLOR_BUTTON_ID: (colorName: PlayerColor) => string = (color
  * プレイヤーの色を変更するボタン
  */
 export class PlayerColorButtons {
-  protected readonly playerId: string
+  protected playerId: string
   protected colorButtons = new Map<PlayerColor, HTMLInputElement>()
 
   protected constructor(
@@ -56,5 +56,9 @@ export class PlayerColorButtons {
   private onClick(color: PlayerColor): void {
     const changeColorEvent = new PlayerColorChangeEvent(this.playerId, color)
     this.eventBus.post(changeColorEvent)
+  }
+
+  public updatePlayerId(playerId: string): void {
+    this.playerId = playerId
   }
 }

--- a/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/renameForm.ts
+++ b/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/renameForm.ts
@@ -17,7 +17,7 @@ export const SEND_BUTTON_ID = 'name-send-button'
  * プレイヤー名変更欄
  */
 export class RenameForm {
-  private readonly playerId: string
+  private playerId: string
 
   public constructor(
     playerId: string,
@@ -64,5 +64,9 @@ export class RenameForm {
         this.eventBus.post(changeNameEvent)
       }
     }
+  }
+
+  public updatePlayerId(playerId: string): void {
+    this.playerId = playerId
   }
 }

--- a/churaverse-plugins-client/src/playerPlugin/ui/setupPlayerUi.ts
+++ b/churaverse-plugins-client/src/playerPlugin/ui/setupPlayerUi.ts
@@ -6,24 +6,43 @@ import { RenameForm } from './playerSetting/renameForm'
 import '@churaverse/keyboard-plugin-client/store/defKeyboardPluginStore'
 import '@churaverse/title-plugin-client/titlePlayerPlugin/defTitlePlayerTransitionData'
 
-export function setupPlayerUi(store: Store<IMainScene>, eventBus: IEventBus<IMainScene>): JoinLeaveLogRenderer {
-  const transitionPluginStore = store.of('transitionPlugin')
-  const playerPluginStore = store.of('playerPlugin')
-  const uiStore = store.of('coreUiPlugin')
-  const keyboardStore = store.of('keyboardPlugin')
-  const player = transitionPluginStore.transitionManager.getReceivedData<ITitleScene>().ownPlayer
-  uiStore.settingDialog.addSection(new SettingSection('playerSetting', 'プレイヤー設定'), 'head')
-  RenameForm.build(playerPluginStore.ownPlayerId, player.name, uiStore.settingDialog, eventBus)
+export class PlayerUi {
+  private readonly renameForm: RenameForm
+  private readonly playerColorButtons: PlayerColorButtons
 
-  PlayerColorButtons.build(playerPluginStore.ownPlayerId, player.color, uiStore.settingDialog, eventBus)
+  public constructor(
+    private readonly store: Store<IMainScene>,
+    eventBus: IEventBus<IMainScene>
+  ) {
+    const transitionPluginStore = store.of('transitionPlugin')
+    const playerPluginStore = store.of('playerPlugin')
+    const uiStore = store.of('coreUiPlugin')
+    const keyboardStore = store.of('keyboardPlugin')
+    const player = transitionPluginStore.transitionManager.getReceivedData<ITitleScene>().ownPlayer
+    uiStore.settingDialog.addSection(new SettingSection('playerSetting', 'プレイヤー設定'), 'head')
+    this.renameForm = RenameForm.build(playerPluginStore.ownPlayerId, player.name, uiStore.settingDialog, eventBus)
 
-  keyboardStore.keySettingWindow.addKeyAction('walkDown', '下に移動')
-  keyboardStore.keySettingWindow.addKeyAction('walkUp', '上に移動')
-  keyboardStore.keySettingWindow.addKeyAction('walkRight', '右に移動')
-  keyboardStore.keySettingWindow.addKeyAction('walkLeft', '左に移動')
+    this.playerColorButtons = PlayerColorButtons.build(
+      playerPluginStore.ownPlayerId,
+      player.color,
+      uiStore.settingDialog,
+      eventBus
+    )
 
-  const fadeOutLogRenderer = uiStore.fadeOutLogRenderer
-  const joinLeaveLogRenderer = new JoinLeaveLogRenderer(fadeOutLogRenderer)
+    keyboardStore.keySettingWindow.addKeyAction('walkDown', '下に移動')
+    keyboardStore.keySettingWindow.addKeyAction('walkUp', '上に移動')
+    keyboardStore.keySettingWindow.addKeyAction('walkRight', '右に移動')
+    keyboardStore.keySettingWindow.addKeyAction('walkLeft', '左に移動')
+  }
 
-  return joinLeaveLogRenderer
+  public setupJoinLeaveLogRenderer(): JoinLeaveLogRenderer {
+    const fadeOutLogRenderer = this.store.of('coreUiPlugin').fadeOutLogRenderer
+    const joinLeaveLogRenderer = new JoinLeaveLogRenderer(fadeOutLogRenderer)
+    return joinLeaveLogRenderer
+  }
+
+  public updatePlayerId(playerId: string): void {
+    this.renameForm.updatePlayerId(playerId)
+    this.playerColorButtons.updatePlayerId(playerId)
+  }
 }


### PR DESCRIPTION
## 概要
参加中のユーザがsocket.ioの接続が切れたことにより退出判定になるが、自プレイヤーは退出処理がされてないため、プレイヤーのいないところからサメが出てきたりという現象が起こる

チケットへのリンク：https://churadata.backlog.com/view/CV-806

## 仕様
正常な挙動として、プレイヤーが退出されずに再接続を試みるようにする。
プレイヤーは、自身で退出するかキックされる以外でゲームから出されることがないようにする。

## 変更
- client側でnetwork接続のイベントを作成
- 上記のイベントに対するコールバック実装