### PR TITLE
実装漏れの修正(アイテム削除等)

### DIFF
--- a/churaverse-plugins-client/src/churarenPlugin/churarenPlayerPlugin/churarenPlayerPlugin.ts
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenPlayerPlugin/churarenPlayerPlugin.ts
@@ -26,6 +26,7 @@ import { DropChurarenItemEvent } from './event/dropChurarenItemEvent'
 import { DropChurarenItemData, DropChurarenItemMessage } from './message/dropChurarenItemMessage'
 import { GamePluginStore } from '@churaverse/game-plugin-client/store/defGamePluginStore'
 import { DeathLog } from '@churaverse/player-plugin-client/ui/deathLog/deathLog'
+import { Position } from 'churaverse-engine-client'
 
 export class ChurarenPlayerPlugin extends BaseGamePlugin {
   public gameId = CHURAREN_CONSTANTS.GAME_ID

--- a/churaverse-plugins-client/src/churarenPlugin/churarenPlayerPlugin/churarenPlayerPlugin.ts
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenPlayerPlugin/churarenPlayerPlugin.ts
@@ -1,7 +1,7 @@
 import { BaseGamePlugin } from '@churaverse/game-plugin-client/domain/baseGamePlugin'
 import { ItemPluginStore } from '@churaverse/churaren-item-plugin-client/store/defItemPluginStore'
 import { NetworkPluginStore } from '@churaverse/network-plugin-client/store/defNetworkPluginStore'
-import { GRID_SIZE, IMainScene, LivingDamageEvent } from 'churaverse-engine-client'
+import { GRID_SIZE, IMainScene, LivingDamageEvent, Position } from 'churaverse-engine-client'
 import { PlayerPluginStore } from '@churaverse/player-plugin-client/store/defPlayerPluginStore'
 import { PlayerRespawnEvent } from '@churaverse/player-plugin-client/event/playerRespawnEvent'
 import { PlayerWalkEvent } from '@churaverse/player-plugin-client/event/playerWalkEvent'
@@ -26,7 +26,6 @@ import { DropChurarenItemEvent } from './event/dropChurarenItemEvent'
 import { DropChurarenItemData, DropChurarenItemMessage } from './message/dropChurarenItemMessage'
 import { GamePluginStore } from '@churaverse/game-plugin-client/store/defGamePluginStore'
 import { DeathLog } from '@churaverse/player-plugin-client/ui/deathLog/deathLog'
-import { Position } from 'churaverse-engine-client'
 
 export class ChurarenPlayerPlugin extends BaseGamePlugin {
   public gameId = CHURAREN_CONSTANTS.GAME_ID

--- a/churaverse-plugins-server/src/churarenPlugin/churarenAlchemyPlugin/churarenAlchemyPlugin.ts
+++ b/churaverse-plugins-server/src/churarenPlugin/churarenAlchemyPlugin/churarenAlchemyPlugin.ts
@@ -97,6 +97,10 @@ export class ChurarenAlchemyPlugin extends BaseGamePlugin {
       items.map((item) => item.kind)
     )
     const deletedItemIds: string[] = items.map((item) => item.id)
+    deletedItemIds.forEach((itemId) => {
+      this.playerItemStore.materialItems.delete(player.id, itemId)
+    })
+
     const alchemizedItem = new AlchemyItem(uniqueId(), alchemizedItemKind)
 
     const alchemizeData: AlchemizeData = {

--- a/churaverse-plugins-server/src/churarenPlugin/churarenAlchemyPlugin/domain/baseAlchemyItemPlugin.ts
+++ b/churaverse-plugins-server/src/churarenPlugin/churarenAlchemyPlugin/domain/baseAlchemyItemPlugin.ts
@@ -12,17 +12,12 @@ export abstract class BaseAlchemyItemPlugin extends BaseGamePlugin {
   public gameId = CHURAREN_CONSTANTS.GAME_ID
   protected abstract alchemyItem: IAlchemyItem
 
-  protected subscribeGameEvent(): void {
-    super.subscribeGameEvent()
+  public listenEvent(): void {
+    super.listenEvent()
     this.bus.subscribeEvent('alchemyItemRegister', this.onAlchemyItemRegister.bind(this))
   }
 
-  protected unsubscribeGameEvent(): void {
-    super.unsubscribeGameEvent()
-    this.bus.unsubscribeEvent('alchemyItemRegister', this.onAlchemyItemRegister.bind(this))
-  }
-
-  private readonly onAlchemyItemRegister = (ev: AlchemyItemRegisterEvent): void => {
+  private onAlchemyItemRegister(ev: AlchemyItemRegisterEvent): void {
     ev.alchemyItemRegister.register(this.alchemyItem.recipe, this.alchemyItem.kind)
   }
 }

--- a/churaverse-plugins-server/src/churarenPlugin/churarenPlugins/churarenPlugins.ts
+++ b/churaverse-plugins-server/src/churarenPlugin/churarenPlugins/churarenPlugins.ts
@@ -1,4 +1,4 @@
-import { alchemyItemPlugins } from '../churarenAlchemyItems/alchemyItemPlugins'
+import { alchemyItemPlugins } from '@churaverse/churaren-alchemy-item-plugins-server'
 import { ChurarenAlchemyPlugin } from '@churaverse/churaren-alchemy-plugin-server'
 import { ChurarenBossPlugin } from '@churaverse/churaren-boss-plugin-server'
 import { ChurarenCorePlugin } from '@churaverse/churaren-core-plugin-server'


### PR DESCRIPTION
## 概要
マージ後に発覚した、現在見つかっている以下の実装漏れを対処する

- churarenPlayerPlugin/churarenPlayerPlugin.tsでのimport忘れ
- 錬金アイテムの作成の際のplayerが持つアイテムの削除
- 錬金アイテムを登録するタイミングの修正
  - イベント発火の後にイベントの登録が行われているため、コールバックが呼ばれない

チケットのリンク：https://churadata.backlog.com/view/CV-822