### PR TITLE
feature/CV-821/ノイズ除去

### DIFF
--- a/churaverse-plugins-client/src/voiceChatPlugin/audio/rnnoiseMicPipeline.ts
+++ b/churaverse-plugins-client/src/voiceChatPlugin/audio/rnnoiseMicPipeline.ts
@@ -3,7 +3,16 @@ import rnnoiseWorkletUrl from '@sapphi-red/web-noise-suppressor/rnnoiseWorklet.j
 import rnnoiseWasmUrl from '@sapphi-red/web-noise-suppressor/rnnoise.wasm?url'
 import rnnoiseSimdWasmUrl from '@sapphi-red/web-noise-suppressor/rnnoise_simd.wasm?url'
 
-// RNNoise を利用してマイク音声を処理し、publish 用の MediaStreamTrack を返す
+/**
+ * RNNoise ベースのマイク用パイプライン.
+ *
+ * 責務:
+ * - getUserMedia でローカルのマイクストリームを取得する
+ * - AudioContext / AudioWorklet (RnnoiseWorkletNode) を通してノイズ抑圧を行う
+ * - LiveKit に publish 可能な MediaStreamTrack を返す
+ *
+ * このクラスは「音声処理」に専念し、LiveKit との連携は VoiceChatSender 側に任せる。
+ */
 export class RnnoiseMicPipeline {
   private audioContext: AudioContext | undefined
   private destination: MediaStreamAudioDestinationNode | undefined
@@ -14,42 +23,53 @@ export class RnnoiseMicPipeline {
   private static wasmBinaryPromise: Promise<ArrayBuffer> | undefined
 
   public async start(): Promise<MediaStreamTrack> {
+    // 既に有効なトラックがある場合は再利用する
     if (this.processedTrack?.readyState === 'live') return this.processedTrack
 
     await this.stop()
 
-    // なるべく緩い制約でマイク取得。失敗時は例外を投げる。
+    // なるべく緩い制約でマイク取得。
+    // 一部環境で厳しすぎる制約を指定すると OverconstrainedError が発生するため、
+    // 基本は { audio: true } とし、失敗時は上位の呼び出し側でフォールバックする。
     this.sourceStream = await navigator.mediaDevices.getUserMedia({ audio: true })
 
     this.audioContext = new AudioContext({ sampleRate: 48_000 })
     this.destination = this.audioContext.createMediaStreamDestination()
 
+    // RNNoise の AudioWorklet をロードして処理ノードを生成
     await this.audioContext.audioWorklet.addModule(rnnoiseWorkletUrl)
     const wasmBinary = await RnnoiseMicPipeline.loadWasmBinary()
     this.workletNode = new RnnoiseWorkletNode(this.audioContext, { maxChannels: 1, wasmBinary })
 
+    // getUserMedia のストリームを AudioContext に接続し、RNNoise 経由で destination へ流す
     const sourceNode = this.audioContext.createMediaStreamSource(this.sourceStream)
     sourceNode.connect(this.workletNode).connect(this.destination)
 
     const [track] = this.destination.stream.getAudioTracks()
     if (track === undefined) {
+      // AudioWorklet 経由のストリームが取得できなかった場合は上位でフォールバックさせる
       throw new Error('Failed to create RNNoise processed microphone track')
     }
 
+    // LiveKit 側で publish する MediaStreamTrack を保持
     this.processedTrack = track
+    // デバッグ用: ブラウザ上で getSettings() を確認できるようにグローバルに公開
     ;(window as unknown as { __processedMicTrack?: MediaStreamTrack }).__processedMicTrack = track
 
     return track
   }
 
   public async stop(): Promise<void> {
+    // publish していたトラックを停止
     this.processedTrack?.stop()
     this.processedTrack = undefined
 
+    // getUserMedia で取得した元のストリームも全て停止
     this.sourceStream?.getTracks().forEach((t) => t.stop())
     this.sourceStream = undefined
 
     try {
+      // RNNoise の内部リソースを解放
       this.workletNode?.destroy()
       this.workletNode?.disconnect()
     } catch {
@@ -67,6 +87,7 @@ export class RnnoiseMicPipeline {
   }
 
   private static async loadWasmBinary(): Promise<ArrayBuffer> {
+    // wasm バイナリは static にキャッシュし、複数回の start() 呼び出しで再利用する
     if (this.wasmBinaryPromise === undefined) {
       this.wasmBinaryPromise = loadRnnoise({ url: rnnoiseWasmUrl, simdUrl: rnnoiseSimdWasmUrl })
     }

--- a/churaverse-plugins-client/src/voiceChatPlugin/audio/rnnoiseMicPipeline.ts
+++ b/churaverse-plugins-client/src/voiceChatPlugin/audio/rnnoiseMicPipeline.ts
@@ -1,0 +1,75 @@
+import { loadRnnoise, RnnoiseWorkletNode } from '@sapphi-red/web-noise-suppressor'
+import rnnoiseWorkletUrl from '@sapphi-red/web-noise-suppressor/rnnoiseWorklet.js?url'
+import rnnoiseWasmUrl from '@sapphi-red/web-noise-suppressor/rnnoise.wasm?url'
+import rnnoiseSimdWasmUrl from '@sapphi-red/web-noise-suppressor/rnnoise_simd.wasm?url'
+
+// RNNoise を利用してマイク音声を処理し、publish 用の MediaStreamTrack を返す
+export class RnnoiseMicPipeline {
+  private audioContext: AudioContext | undefined
+  private destination: MediaStreamAudioDestinationNode | undefined
+  private sourceStream: MediaStream | undefined
+  private processedTrack: MediaStreamTrack | undefined
+  private workletNode: RnnoiseWorkletNode | undefined
+
+  private static wasmBinaryPromise: Promise<ArrayBuffer> | undefined
+
+  public async start(): Promise<MediaStreamTrack> {
+    if (this.processedTrack?.readyState === 'live') return this.processedTrack
+
+    await this.stop()
+
+    // なるべく緩い制約でマイク取得。失敗時は例外を投げる。
+    this.sourceStream = await navigator.mediaDevices.getUserMedia({ audio: true })
+
+    this.audioContext = new AudioContext({ sampleRate: 48_000 })
+    this.destination = this.audioContext.createMediaStreamDestination()
+
+    await this.audioContext.audioWorklet.addModule(rnnoiseWorkletUrl)
+    const wasmBinary = await RnnoiseMicPipeline.loadWasmBinary()
+    this.workletNode = new RnnoiseWorkletNode(this.audioContext, { maxChannels: 1, wasmBinary })
+
+    const sourceNode = this.audioContext.createMediaStreamSource(this.sourceStream)
+    sourceNode.connect(this.workletNode).connect(this.destination)
+
+    const [track] = this.destination.stream.getAudioTracks()
+    if (track === undefined) {
+      throw new Error('Failed to create RNNoise processed microphone track')
+    }
+
+    this.processedTrack = track
+    ;(window as unknown as { __processedMicTrack?: MediaStreamTrack }).__processedMicTrack = track
+
+    return track
+  }
+
+  public async stop(): Promise<void> {
+    this.processedTrack?.stop()
+    this.processedTrack = undefined
+
+    this.sourceStream?.getTracks().forEach((t) => t.stop())
+    this.sourceStream = undefined
+
+    try {
+      this.workletNode?.destroy()
+      this.workletNode?.disconnect()
+    } catch {
+      // ignore
+    }
+    this.workletNode = undefined
+
+    this.destination?.disconnect()
+    this.destination = undefined
+
+    if (this.audioContext !== undefined) {
+      await this.audioContext.close()
+    }
+    this.audioContext = undefined
+  }
+
+  private static async loadWasmBinary(): Promise<ArrayBuffer> {
+    if (this.wasmBinaryPromise === undefined) {
+      this.wasmBinaryPromise = loadRnnoise({ url: rnnoiseWasmUrl, simdUrl: rnnoiseSimdWasmUrl })
+    }
+    return await this.wasmBinaryPromise
+  }
+}

--- a/churaverse-plugins-client/src/voiceChatPlugin/audio/rnnoiseMicPipeline.ts
+++ b/churaverse-plugins-client/src/voiceChatPlugin/audio/rnnoiseMicPipeline.ts
@@ -88,6 +88,10 @@ export class RnnoiseMicPipeline {
     // wasm バイナリは static にキャッシュし、複数回の start() 呼び出しで再利用する
     if (this.wasmBinaryPromise === undefined) {
       this.wasmBinaryPromise = loadRnnoise({ url: rnnoiseWasmUrl, simdUrl: rnnoiseSimdWasmUrl })
+      this.wasmBinaryPromise.catch(() => {
+        // 失敗した場合は次回以降に再度ロードを試みるため、キャッシュをクリアする
+        this.wasmBinaryPromise = undefined
+      })
     }
     return await this.wasmBinaryPromise
   }

--- a/churaverse-plugins-client/src/voiceChatPlugin/audio/rnnoiseMicPipeline.ts
+++ b/churaverse-plugins-client/src/voiceChatPlugin/audio/rnnoiseMicPipeline.ts
@@ -1,10 +1,9 @@
 import { loadRnnoise, RnnoiseWorkletNode } from '@sapphi-red/web-noise-suppressor'
-// eslint-disable-next-line import/no-unresolved -- Vite resolves `?url` imports at build time
+/* eslint-disable import/no-unresolved -- Vite resolves `?url` imports at build time */
 import rnnoiseWorkletUrl from '@sapphi-red/web-noise-suppressor/rnnoiseWorklet.js?url'
-// eslint-disable-next-line import/no-unresolved -- Vite resolves `?url` imports at build time
 import rnnoiseWasmUrl from '@sapphi-red/web-noise-suppressor/rnnoise.wasm?url'
-// eslint-disable-next-line import/no-unresolved -- Vite resolves `?url` imports at build time
 import rnnoiseSimdWasmUrl from '@sapphi-red/web-noise-suppressor/rnnoise_simd.wasm?url'
+/* eslint-enable import/no-unresolved */
 
 /**
  * RNNoise ベースのマイク用パイプライン.
@@ -17,13 +16,13 @@ import rnnoiseSimdWasmUrl from '@sapphi-red/web-noise-suppressor/rnnoise_simd.wa
  * このクラスは「音声処理」に専念し、LiveKit との連携は VoiceChatSender 側に任せる。
  */
 export class RnnoiseMicPipeline {
-  private audioContext: AudioContext | undefined
-  private destination: MediaStreamAudioDestinationNode | undefined
-  private sourceStream: MediaStream | undefined
-  private processedTrack: MediaStreamTrack | undefined
-  private workletNode: RnnoiseWorkletNode | undefined
+  private audioContext?: AudioContext 
+  private destination?: MediaStreamAudioDestinationNode 
+  private sourceStream?: MediaStream 
+  private processedTrack?: MediaStreamTrack 
+  private workletNode?: RnnoiseWorkletNode 
 
-  private static wasmBinaryPromise: Promise<ArrayBuffer> | undefined
+  private static wasmBinaryPromise?: Promise<ArrayBuffer> 
 
   public async start(): Promise<MediaStreamTrack> {
     if (this.processedTrack?.readyState === 'live') {

--- a/churaverse-plugins-client/src/voiceChatPlugin/audio/rnnoiseMicPipeline.ts
+++ b/churaverse-plugins-client/src/voiceChatPlugin/audio/rnnoiseMicPipeline.ts
@@ -1,6 +1,9 @@
 import { loadRnnoise, RnnoiseWorkletNode } from '@sapphi-red/web-noise-suppressor'
+// eslint-disable-next-line import/no-unresolved -- Vite resolves `?url` imports at build time
 import rnnoiseWorkletUrl from '@sapphi-red/web-noise-suppressor/rnnoiseWorklet.js?url'
+// eslint-disable-next-line import/no-unresolved -- Vite resolves `?url` imports at build time
 import rnnoiseWasmUrl from '@sapphi-red/web-noise-suppressor/rnnoise.wasm?url'
+// eslint-disable-next-line import/no-unresolved -- Vite resolves `?url` imports at build time
 import rnnoiseSimdWasmUrl from '@sapphi-red/web-noise-suppressor/rnnoise_simd.wasm?url'
 
 /**
@@ -71,13 +74,13 @@ export class RnnoiseMicPipeline {
       throw new Error('Destination node is not initialized')
     }
 
-    const [tracks] = this.destination.stream.getAudioTracks()
+    const [track] = this.destination.stream.getAudioTracks()
 
-    if (tracks === undefined) {
+    if (track === undefined) {
       throw new Error('Failed to create RNNoise processed microphone track')
     }
 
-    return tracks
+    return track
   }
 
   public async stop(): Promise<void> {

--- a/churaverse-plugins-client/src/voiceChatPlugin/audio/rnnoiseMicPipeline.ts
+++ b/churaverse-plugins-client/src/voiceChatPlugin/audio/rnnoiseMicPipeline.ts
@@ -23,38 +23,61 @@ export class RnnoiseMicPipeline {
   private static wasmBinaryPromise: Promise<ArrayBuffer> | undefined
 
   public async start(): Promise<MediaStreamTrack> {
-    // 既に有効なトラックがある場合は再利用する
-    if (this.processedTrack?.readyState === 'live') return this.processedTrack
+    if (this.processedTrack?.readyState === 'live') {
+      return this.processedTrack
+    }
 
     await this.stop()
 
+    try {
+      await this.initializePipeline()
+      const track = this.getProcessedTrack()
+      this.processedTrack = track
+      return track
+      // 例外が発生した場合は途中まで作成されたリソースを解放する
+    } catch (error) {
+      await this.stop()
+      throw error
+    }
+  }
+
+  private async initializePipeline(): Promise<void> {
     // なるべく緩い制約でマイク取得。
     // 一部環境で厳しすぎる制約を指定すると OverconstrainedError が発生するため、
     // 基本は { audio: true } とし、失敗時は上位の呼び出し側でフォールバックする。
     this.sourceStream = await navigator.mediaDevices.getUserMedia({ audio: true })
-
     this.audioContext = new AudioContext({ sampleRate: 48_000 })
     this.destination = this.audioContext.createMediaStreamDestination()
 
     // RNNoise の AudioWorklet をロードして処理ノードを生成
     await this.audioContext.audioWorklet.addModule(rnnoiseWorkletUrl)
+
     const wasmBinary = await RnnoiseMicPipeline.loadWasmBinary()
-    this.workletNode = new RnnoiseWorkletNode(this.audioContext, { maxChannels: 1, wasmBinary })
+    this.workletNode = new RnnoiseWorkletNode(this.audioContext, {
+      maxChannels: 1,
+      wasmBinary
+    })
 
     // getUserMedia のストリームを AudioContext に接続し、RNNoise 経由で destination へ流す
     const sourceNode = this.audioContext.createMediaStreamSource(this.sourceStream)
-    sourceNode.connect(this.workletNode).connect(this.destination)
 
-    const [track] = this.destination.stream.getAudioTracks()
-    if (track === undefined) {
-      // AudioWorklet 経由のストリームが取得できなかった場合は上位でフォールバックさせる
+    // 型確定してから接続
+    const workletAudioNode = this.workletNode as unknown as AudioNode
+    sourceNode.connect(workletAudioNode).connect(this.destination)
+  }
+
+  private getProcessedTrack(): MediaStreamTrack {
+    if (this.destination === undefined) {
+      throw new Error('Destination node is not initialized')
+    }
+
+    const [tracks] = this.destination.stream.getAudioTracks()
+
+    if (tracks === undefined) {
       throw new Error('Failed to create RNNoise processed microphone track')
     }
 
-    // LiveKit 側で publish する MediaStreamTrack を保持
-    this.processedTrack = track
-
-    return track
+    return tracks
   }
 
   public async stop(): Promise<void> {
@@ -63,7 +86,9 @@ export class RnnoiseMicPipeline {
     this.processedTrack = undefined
 
     // getUserMedia で取得した元のストリームも全て停止
-    this.sourceStream?.getTracks().forEach((t) => t.stop())
+    this.sourceStream?.getTracks().forEach((track) => {
+      track.stop()
+    })
     this.sourceStream = undefined
 
     try {

--- a/churaverse-plugins-client/src/voiceChatPlugin/audio/rnnoiseMicPipeline.ts
+++ b/churaverse-plugins-client/src/voiceChatPlugin/audio/rnnoiseMicPipeline.ts
@@ -53,8 +53,6 @@ export class RnnoiseMicPipeline {
 
     // LiveKit 側で publish する MediaStreamTrack を保持
     this.processedTrack = track
-    // デバッグ用: ブラウザ上で getSettings() を確認できるようにグローバルに公開
-    ;(window as unknown as { __processedMicTrack?: MediaStreamTrack }).__processedMicTrack = track
 
     return track
   }

--- a/churaverse-plugins-client/src/voiceChatPlugin/package.json
+++ b/churaverse-plugins-client/src/voiceChatPlugin/package.json
@@ -35,6 +35,7 @@
   "license": "MIT",
   "dependencies": {
     "phaser": "^3.80.1",
+    "@sapphi-red/web-noise-suppressor": "^0.3.5",
     "@churaverse/core-ui-plugin-client": "~0.1.0",
     "@churaverse/debug-screen-plugin-client": "~0.1.0",
     "@churaverse/network-plugin-client": "~0.1.0",

--- a/churaverse-plugins-client/src/voiceChatPlugin/url.d.ts
+++ b/churaverse-plugins-client/src/voiceChatPlugin/url.d.ts
@@ -1,0 +1,9 @@
+declare module '@sapphi-red/web-noise-suppressor/*.js?url' {
+  const url: string
+  export default url
+}
+
+declare module '@sapphi-red/web-noise-suppressor/*.wasm?url' {
+  const url: string
+  export default url
+}

--- a/churaverse-plugins-client/src/voiceChatPlugin/voiceChatSender.ts
+++ b/churaverse-plugins-client/src/voiceChatPlugin/voiceChatSender.ts
@@ -93,10 +93,6 @@ export class VoiceChatSender implements IVoiceChatSender {
         source: Track.Source.Microphone,
         name: 'microphone-processed',
       })
-      // デバッグ用: publish したトラックと Room をグローバルに公開しておき、
-      // ブラウザコンソールから getSettings などを確認できるようにする
-      ;(window as unknown as { __micPub?: LocalTrackPublication }).__micPub = this.micPublication
-      ;(window as unknown as { __lkRoom?: Room }).__lkRoom = this.room
       console.info('[MicPipeline] published track', this.micPublication?.track?.mediaStreamTrack?.getSettings())
       return this.micPublication.track !== undefined
     } catch (error) {

--- a/churaverse-plugins-client/src/voiceChatPlugin/voiceChatSender.ts
+++ b/churaverse-plugins-client/src/voiceChatPlugin/voiceChatSender.ts
@@ -100,6 +100,7 @@ export class VoiceChatSender implements IVoiceChatSender {
       // パイプラインの立ち上げに失敗した場合でも、
       // 完全にマイクが使えなくなると困るため LiveKit のデフォルト実装にフォールバックする。
       await this.room.localParticipant.setMicrophoneEnabled(true)
+      this.micPublication = this.room.localParticipant.getTrack(Track.Source.Microphone)
       return this.room.localParticipant.isMicrophoneEnabled
     } finally {
       this.isStarting = false


### PR DESCRIPTION
# RNNoise を用いたボイスチャット送信パイプラインの導入


チケットへのリンク：https://churadata.backlog.com/view/CV-821



## 注意

このPRは churaverse_private の同名PR https://github.com/churadata/churaverse_private/pull/403 に依存しており、両方を同時に適用しなければ正常に動作しません。

この PR は「音声送信パス」に対する変更です。
以下の手順（install → build → npm_link_cvPackages_path.txt 設定 → link 実行）を行わないと frontend から変更が反映されません。

- voiceChatPlugin 側で `npm install` → `npm run build`
- `churaverse_private/frontend/npm_link_cvPackages_path.txt` に voiceChatPlugin のパスを追記
  例: `churaverse-plugins/churaverse-plugins-client/src/voiceChatPlugin`
-  Docker再起動


## 概要
- ボイスチャット送信経路に RNNoise ベースのノイズ抑制パイプラインを追加
- LiveKit の「マイク ON/OFF」だけに任せるのではなく、
  一度 WebAudio 上で RNNoise に通したトラックを LiveKit に publish する構成に変更
- パイプラインの初期化に失敗した場合は、従来どおり `setMicrophoneEnabled(true/false)` にフォールバック

## 技術的背景

■ Churaverseの音声パイプライン全体像（送信側）
従来：
- ブラウザ → LiveKit（setMicrophoneEnabled）→ そのまま他クライアントへ配信
- アプリ側は「音が ON か OFF か」だけを制御しており、音声内容には介入していない

今回：
- ブラウザ → WebAudio (AudioContext) → RNNoise (AudioWorklet + wasm) → LiveKit → 他クライアント
- つまり「送る前に一度だけノイズ抑制をかけてから publish」するように変更

■ 使っているライブラリと役割
- `@sapphi-red/web-noise-suppressor`
  - RNNoise を WebAudio の AudioWorklet としてラップしたライブラリ
  - 48kHz／maxChannels:1 を前提としたリアルタイム音声処理ノードを提供
- これを使うことで「自前で wasm を直接叩く」のではなく、
  「AudioWorkletNode に接続して publishTrack する」という標準的な形で統合している

## 主な変更点

■ RnnoiseMicPipeline の追加
- `getUserMedia({ audio: true })` でローカルマイクストリームを取得
- `AudioContext(48kHz)` を作成し、`MediaStreamDestination` に接続
- `audioWorklet.addModule(rnnoiseWorkletUrl)` で RNNoise の Worklet をロード
- `loadRnnoise({ url, simdUrl })` で wasm バイナリをロード（static Promise でキャッシュ）
- `RnnoiseWorkletNode` を生成し、以下の構成で接続
  - `MediaStreamSource(getUserMedia の出力) → RnnoiseWorkletNode → MediaStreamDestination`
- `destination.stream.getAudioTracks()` から 1 本の `MediaStreamTrack` を取得し、
  LiveKit から publish できる形で返す

■ VoiceChatSender の送信処理を差し替え
- 従来は `setMicrophoneEnabled(true/false)` で LiveKit にマイク ON/OFF を依頼していた
- 今回は以下のように変更：
  1. 既に `Track.Source.Microphone` のトラックが存在する場合は、
     `unpublishTrack + stop()` で必ず一度クリーンにする  
     → 「マイクトラックが二重に publish される」問題（実際に LiveKit から warning が出ていた）を防止
  2. `RnnoiseMicPipeline.start()` から処理済みトラックを取得
  3. `publishTrack(processedTrack, { source: Microphone, name: 'microphone-processed' })` を実行
- start/stop の多重実行防止のため `isStarting` / `isStopping` を導入

■ フォールバック戦略
- RNNoise パイプラインが初期化に失敗した場合（マイク権限 NG・環境依存エラーなど）は：
  - エラーログを出しつつ `setMicrophoneEnabled(true)` を呼び出し、
    従来の「生のマイク音」を送るルートに切り替える
- これにより、改善のための変更が「マイクが一切使えない」状況を作らないようにしている

■ デバッグ用フック
- デバッグ用途として、以下を `window` に公開：
  - `window.__processedMicTrack`: RNNoise を通した後の MediaStreamTrack
  - `window.__micPub`: LiveKit に publish されたトラックの Publication
  - `window.__lkRoom`: 利用中の LiveKit Room インスタンス
- これにより、コンソールから `getSettings()` や `localParticipant.audioTracks` を直接確認できる

■ 依存と型定義
- `@sapphi-red/web-noise-suppressor` を依存に追加
- `url.d.ts` を追加し、`rnnoiseWorklet.js?url` / `*.wasm?url` の import に対する TS の型エラーを解消

## 動作確認（マイク ON 前提）

- 以下の操作はすべてブラウザの開発者ツール内で行います
- 以下の現象が発生すれば、正常に動作していることを示します。詳細は Slack の churaverse チャンネルの資料をご参照ください。

前提条件：
- ローカル環境で起動している
- ブラウザでゲームに接続し、マイク権限を許可している
- 画面右上のマイクアイコンで「マイク ON」にした状態

1. Console ログの確認
   - マイク ON 時、DevTools Console に
     `[MicPipeline] published track { ... }`
     が出力されていること。

2. トラック設定の確認
   - Console で下記を実行：
     - `window.__processedMicTrack?.getSettings()`
     - `window.__micPub?.track?.mediaStreamTrack?.getSettings()`
   - 両方とも `sampleRate: 48000` になっていること。

3. RNNoise リソースのロード確認
   - Network タブを開き、フィルタに `rnnoise` と入力
   - `rnnoiseWorklet.js` / `rnnoise.wasm` / `rnnoise_simd.wasm` が 200 もしくは 304 で読み込まれていること。

4. AudioWorklet スレッドで RNNoise が動作していることの確認
   - Chrome DevTools の Performance タブで録画を開始
   - 録画中にマイク ON のまま数秒しゃべる
   - 停止後、「Realtime AudioWorklet thread」を展開し、Bottom-up もしくは Call tree を見る：
     - `workletProcessor.js`（ライブラリ内の RNNoise Processor）
     - 多数の `wasm-function[...]`
     が時間軸上で継続して動作していること。

6. ノイズ抑制の体感確認
   - 同一マシンでブラウザタブを 2 つ開き、両方ローカルの Churaverse に接続
   - タブ A: マイク ON（話者）、タブ B: マイク OFF（リスナー）で待機
   - タブ A で「声 + キーボード打鍵 + 環境音」を混ぜて発声し、
     タブ B の音を聞く：
     - 人声が前に出ている
     - 打鍵音・環境ノイズがある程度抑制されている
     ことを確認する

