### PR TITLE
feature/CV-850/move-while-open

### DIFF
--- a/churaverse-plugins-client/src/keyboardPlugin/keyActionManager.ts
+++ b/churaverse-plugins-client/src/keyboardPlugin/keyActionManager.ts
@@ -72,8 +72,9 @@ export class KeyActionManager<Scene extends Scenes>
   }
 
   public update(dt: number): void {
+    const isTyping = document.activeElement instanceof HTMLInputElement || document.activeElement instanceof HTMLTextAreaElement
     this.keyActionObservers.forEach((observer) => {
-      observer.update(dt, this.keyActionReceiver)
+      observer.update(dt, this.keyActionReceiver, isTyping)
     })
   }
 }

--- a/churaverse-plugins-client/src/keyboardPlugin/keyActionObserver.ts
+++ b/churaverse-plugins-client/src/keyboardPlugin/keyActionObserver.ts
@@ -24,11 +24,13 @@ export class KeyActionObserver<Scene extends Scenes> {
    * キーの入力状態を更新し、条件が満たされている場合はlistenerを実行する
    * @param dt
    * @param keyActionReceiver
+   * @param isTyping
    */
-  public update(dt: number, keyActionReceiver: KeyActionReceiver<Scene>): void {
+  public update(dt: number, keyActionReceiver: KeyActionReceiver<Scene>, isTyping: boolean): void {
     if (
       this.myKeyAction.keyContext === 'universal' ||
-      this.myKeyAction.keyContext === this.keyContextManager.nowContext
+      this.myKeyAction.keyContext === this.keyContextManager.nowContext ||
+      this.myKeyAction.keyContext === 'inGame' && !isTyping
     ) {
       this._update(dt, keyActionReceiver)
     } else {


### PR DESCRIPTION
# 概要
チケットへのリンク：https://churadata.backlog.com/view/CV-850


## 変更内容
- チャットや参加者リストなどを開いていると移動できない問題の解決
  - ダイアログを単純に開いた状態では移動可能
  - ダイアログ内のテキスト入力や選択をしている場合は移動不可能

## 補足
- 入力中かどうかの判定に`isTyping`を利用しているが、命名は`isInputting`などの方が良いか？



## チェックリスト
- [x] 最新の master ブランチを作業ブランチに取り込んでいますか？
- [x] 最後に Push したその状態は動作確認をしていますか？
- [x] File changed は確認しましたか？
  - print デバッグなどで使用した print 文や log 出力は消しましたか？
  - 不必要なメモや使わなくなったコード残していないですか？
  - 意図していない変更や修正が含まれていないですか？
  - 第三者が見てよくわからない命名などになっていませんか？
- [x] マージできる状態になっていますか？
  - コンフリクトは起きていないですか？
