### PR TITLE
プレイヤーの初期カラーをランダムに設定

### DIFF
--- a/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/titlePlayerPlugin.ts
+++ b/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/titlePlayerPlugin.ts
@@ -67,7 +67,7 @@ export class TitlePlayerPlugin extends BasePlugin<ITitleScene> {
     initTitlePlayerPluginStore(
       this.store,
       this.ownPlayer,
-      this.createPreviewPlayer(),
+      this.createPreviewPlayer(this.ownPlayer),
       new TitleNameFieldRenderer(this.bus),
       new TitlePlayerRoleRenderer(this.scene, this.playerSetupInfoReader)
     )
@@ -86,22 +86,22 @@ export class TitlePlayerPlugin extends BasePlugin<ITitleScene> {
       pos,
       direction,
       this.playerSetupInfoReader.read().name ?? '',
-      this.playerSetupInfoReader.read().color ?? PLAYER_COLOR_NAMES[4],
+      this.playerSetupInfoReader.read().color ??
+        PLAYER_COLOR_NAMES[Math.floor(Math.random() * PLAYER_COLOR_NAMES.length)],
       DEFAULT_HP,
       this.playerSetupInfoReader.read().role ?? 'user'
     )
     return ownPlayer
   }
 
-  private createPreviewPlayer(): IPlayerRenderer {
+  private createPreviewPlayer(ownPlayer: Player): IPlayerRenderer {
     const pos = new Position(0, 0)
-    const direction = Direction.down
     const previewPlayer = this.playerRendererFactory.build(
       pos,
-      direction,
-      this.playerSetupInfoReader.read().name ?? '',
-      this.playerSetupInfoReader.read().color ?? PLAYER_COLOR_NAMES[4],
-      DEFAULT_HP
+      ownPlayer.direction,
+      ownPlayer.name,
+      ownPlayer.color,
+      ownPlayer.hp
     )
     return previewPlayer
   }


### PR DESCRIPTION
# 概要
チケットへのリンク：https://churadata.backlog.com/view/CV-859


## 変更内容
- ちゅらバースにアクセスした際に、初期カラーがグレーに固定されているため、ランダムになるように修正

## 注意点
`frontend/npm_link_cvPackages_path.txt`には以下のパスを記載すると動作確認できます。
```
churaverse-plugins/churaverse-plugins-client/src/titlePlugins
```

Cookieにplayerカラーが保存されている場合は、ランダムなカラーを生成しません。
そのため、同じブラウザで動作確認をする際は、デベロッパーツールからCookieの情報を削除し、動作確認をお願いしたいです。

## 補足
- `createPreviewPlayer` 関数に、`createOwnPlayer` 関数で作成したPlayerクラスを引数として渡している。
  - playerのcolorをランダムにしたため、統一したい意図と、再利用できるため、変更を行いました。


## チェックリスト
- [x] 最新の master ブランチを作業ブランチに取り込んでいますか？
- [x] 最後に Push したその状態は動作確認をしていますか？
- [x] File changed は確認しましたか？
  - print デバッグなどで使用した print 文や log 出力は消しましたか？
  - 不必要なメモや使わなくなったコード残していないですか？
  - 意図していない変更や修正が含まれていないですか？
  - 第三者が見てよくわからない命名などになっていませんか？
- [x] マージできる状態になっていますか？
  - コンフリクトは起きていないですか？