### PR TITLE
プレイヤー名の文字数制限と空白連続使用禁止、ユーザの入力数を表示するレスポンスの実装

### DIFF
--- a/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/components/RenameComponent.module.scss
+++ b/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/components/RenameComponent.module.scss
@@ -29,7 +29,7 @@
   border-radius: 4px;
   padding: 6px 10px;
   white-space: nowrap;
-  z-index: 10;
+  text-align: left;
 
   ul {
     margin: 0;

--- a/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/components/RenameComponent.module.scss
+++ b/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/components/RenameComponent.module.scss
@@ -41,40 +41,9 @@
   display: block;
 }
 
-.indicator {
-  position: relative;
-  width: 40px;
-  height: 40px;
-  flex-shrink: 0;
-}
-
-.svg {
-  width: 100%;
-  height: 100%;
-  transform: rotate(-90deg);
-}
-
-.track {
-  fill: none;
-  stroke: #ddd;
-  stroke-width: 3;
-}
-
-.meter {
-  fill: none;
-  stroke: #4caf50;
-  stroke-width: 3;
-  stroke-dasharray: 100;
-  stroke-dashoffset: 100;
-  transition: stroke-dashoffset 0.2s;
-}
-
 .count {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  font-size: 11px;
+  font-size: 15px;
+  flex-shrink: 0;
 }
 
 .sendButton {

--- a/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/components/RenameComponent.module.scss
+++ b/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/components/RenameComponent.module.scss
@@ -2,14 +2,83 @@
   width: 100%;
 }
 
+.inputRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.inputWrapper {
+  position: relative;
+}
+
 .textField {
   padding: 0 15px;
-  margin-right: 5px;
-  width: 70%;
+  width: 100%;
   height: 35px;
+}
+
+.tooltip {
+  display: none;
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  background: rgba(0, 0, 0, 0.75);
+  color: #fff;
+  font-size: 12px;
+  border-radius: 4px;
+  padding: 6px 10px;
+  white-space: nowrap;
+  z-index: 10;
+
+  ul {
+    margin: 0;
+    padding-left: 16px;
+  }
+}
+
+.inputWrapper:hover .tooltip {
+  display: block;
+}
+
+.indicator {
+  position: relative;
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+}
+
+.svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.track {
+  fill: none;
+  stroke: #ddd;
+  stroke-width: 3;
+}
+
+.meter {
+  fill: none;
+  stroke: #4caf50;
+  stroke-width: 3;
+  stroke-dasharray: 100;
+  stroke-dashoffset: 100;
+  transition: stroke-dashoffset 0.2s;
+}
+
+.count {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 11px;
 }
 
 .sendButton {
   width: 20%;
   height: 35px;
+  flex-shrink: 0;
 }

--- a/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/components/RenameComponent.module.scss
+++ b/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/components/RenameComponent.module.scss
@@ -21,7 +21,7 @@
 .tooltip {
   display: none;
   position: absolute;
-  top: calc(100% + 4px);
+  bottom: calc(100% + 4px);
   left: 0;
   background: rgba(0, 0, 0, 0.75);
   color: #fff;

--- a/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/components/RenameComponent.tsx
+++ b/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/components/RenameComponent.tsx
@@ -5,9 +5,10 @@ import style from './RenameComponent.module.scss'
 
 interface Props {
   readonly defaultName: string
+  readonly maxLength: number
 }
 
-export const RenameFormComponent: JSXFunc<Props> = ({ defaultName }: Props) => {
+export const RenameFormComponent: JSXFunc<Props> = ({ defaultName, maxLength }: Props) => {
   return (
     <div className={style.container}>
       <div className={dialogStyle.itemLabel}>プレイヤー名</div>
@@ -22,12 +23,12 @@ export const RenameFormComponent: JSXFunc<Props> = ({ defaultName }: Props) => {
           />
           <div className={style.tooltip}>
             <ul>
-              <li>1文字以上15文字以下</li>
+              <li>1文字以上{maxLength}文字以下</li>
               <li>連続するスペースは使用不可</li>
             </ul>
           </div>
         </div>
-        <span className={style.count} id="rename-count">0/15</span>
+        <span className={style.count} id="rename-count">0/{maxLength}</span>
         <button className={style.sendButton} id={SEND_BUTTON_ID}>
           OK
         </button>

--- a/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/components/RenameComponent.tsx
+++ b/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/components/RenameComponent.tsx
@@ -11,14 +11,29 @@ export const RenameFormComponent: JSXFunc<Props> = ({ defaultName }: Props) => {
   return (
     <div className={style.container}>
       <div className={dialogStyle.itemLabel}>プレイヤー名</div>
-      <div>
-        <input
-          className={style.textField}
-          type="text"
-          id={TEXT_FIELD_ID}
-          placeholder="Enter your name"
-          defaultValue={defaultName}
-        />
+      <div className={style.inputRow}>
+        <div className={style.inputWrapper}>
+          <input
+            className={style.textField}
+            type="text"
+            id={TEXT_FIELD_ID}
+            placeholder="Enter your name"
+            defaultValue={defaultName}
+          />
+          <div className={style.tooltip}>
+            <ul>
+              <li>1文字以上15文字以下</li>
+              <li>連続するスペースは使用不可</li>
+            </ul>
+          </div>
+        </div>
+        <div className={style.indicator}>
+          <svg viewBox="0 0 36 36" className={style.svg}>
+            <circle className={style.track} cx="18" cy="18" r="15.9" />
+            <circle className={style.meter} cx="18" cy="18" r="15.9" id="rename-meter" />
+          </svg>
+          <span className={style.count} id="rename-count">0</span>
+        </div>
         <button className={style.sendButton} id={SEND_BUTTON_ID}>
           OK
         </button>

--- a/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/components/RenameComponent.tsx
+++ b/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/components/RenameComponent.tsx
@@ -27,13 +27,7 @@ export const RenameFormComponent: JSXFunc<Props> = ({ defaultName }: Props) => {
             </ul>
           </div>
         </div>
-        <div className={style.indicator}>
-          <svg viewBox="0 0 36 36" className={style.svg}>
-            <circle className={style.track} cx="18" cy="18" r="15.9" />
-            <circle className={style.meter} cx="18" cy="18" r="15.9" id="rename-meter" />
-          </svg>
-          <span className={style.count} id="rename-count">0</span>
-        </div>
+        <span className={style.count} id="rename-count">0/15</span>
         <button className={style.sendButton} id={SEND_BUTTON_ID}>
           OK
         </button>

--- a/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/renameForm.ts
+++ b/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/renameForm.ts
@@ -45,6 +45,22 @@ export class RenameForm {
 
   private setupTextField(): HTMLInputElement {
     const textField = DomManager.getElementById<HTMLInputElement>(TEXT_FIELD_ID)
+    const MAX_COUNT = 15
+
+    textField.oninput = () => {
+      const count = textField.value.length
+      const meter = document.getElementById('rename-meter')
+      const countEl = document.getElementById('rename-count')
+      if (meter !== null) {
+        const offset = Math.max(0, 100 - (count / MAX_COUNT) * 100)
+        meter.style.strokeDashoffset = String(offset)
+        meter.style.stroke = count > MAX_COUNT ? '#f44336' : '#4caf50'
+      }
+      if (countEl !== null) {
+        countEl.textContent = String(count)
+      }
+    }
+    textField.dispatchEvent(new Event('input')) // 初期値に対してもインジケーターが正しく表示されるようにするため、inputイベントを発火させる
 
     return textField
   }
@@ -57,13 +73,34 @@ export class RenameForm {
 
     sendButton.onclick = () => {
       // 入力欄の文字列を取得
-      const name = textField.value
-      if (name !== '') {
-        // プレイヤーの名前を変更する
-        const changeNameEvent = new PlayerNameChangeEvent(this.playerId, name)
-        this.eventBus.post(changeNameEvent)
+      const name = textField.value.trim()
+      const errors = this.validate(name)
+
+      if (errors.length > 0) {
+        alert(errors.join('\n'))
+        return
       }
+
+      // プレイヤーの名前を変更する
+      const changeNameEvent = new PlayerNameChangeEvent(this.playerId, name)
+      this.eventBus.post(changeNameEvent)
     }
+  }
+
+  private validate(name: string): string[] {
+    const errors: string[] = []
+
+    //名前の長さが15文字以下かを判定（全角・半角問わず）
+    if (name.length === 0 || name.length > 15) {
+      errors.push('名前は1文字以上15文字以下で入力してください')
+    }
+
+    //名前の途中で2つ以上の連続したスペースがあるかを判定
+    if (/\s{2,}/.test(name)) {
+      errors.push('名前に連続したスペースを含めないでください')
+    }
+
+    return errors
   }
 
   public updatePlayerId(playerId: string): void {

--- a/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/renameForm.ts
+++ b/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/renameForm.ts
@@ -50,19 +50,12 @@ export class RenameForm {
 
   private setupTextField(): HTMLInputElement {
     const textField = DomManager.getElementById<HTMLInputElement>(TEXT_FIELD_ID)
-    const meter = document.getElementById('rename-meter')
-    const countEl = document.getElementById('rename-count')
-    const MAX_COUNT = 15
+    const countEl = document.getElementById(RENAME_COUNT_ID)
 
     textField.oninput = () => {
       const count = textField.value.length
-      if (meter !== null) {
-        const offset = Math.max(0, 100 - (count / MAX_COUNT) * 100)
-        meter.style.strokeDashoffset = String(offset)
-        meter.style.stroke = count > MAX_COUNT ? '#f44336' : '#4caf50'
-      }
       if (countEl !== null) {
-        countEl.textContent = String(count)
+        countEl.textContent = `${count}/15`
       }
     }
 

--- a/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/renameForm.ts
+++ b/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/renameForm.ts
@@ -37,7 +37,7 @@ export class RenameForm {
   ) {
     this.playerId = playerId
 
-    const content = DomManager.jsxToDom(RenameFormComponent({ defaultName: name }))
+    const content = DomManager.jsxToDom(RenameFormComponent({ defaultName: name, maxLength: MAX_PLAYER_NAME_LENGTH }))
     settingDialog.addContent('playerSetting', content)
 
     const textField = this.setupTextField()

--- a/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/renameForm.ts
+++ b/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/renameForm.ts
@@ -45,12 +45,12 @@ export class RenameForm {
 
   private setupTextField(): HTMLInputElement {
     const textField = DomManager.getElementById<HTMLInputElement>(TEXT_FIELD_ID)
+    const meter = document.getElementById('rename-meter')
+    const countEl = document.getElementById('rename-count')
     const MAX_COUNT = 15
 
     textField.oninput = () => {
       const count = textField.value.length
-      const meter = document.getElementById('rename-meter')
-      const countEl = document.getElementById('rename-count')
       if (meter !== null) {
         const offset = Math.max(0, 100 - (count / MAX_COUNT) * 100)
         meter.style.strokeDashoffset = String(offset)
@@ -60,6 +60,7 @@ export class RenameForm {
         countEl.textContent = String(count)
       }
     }
+
     textField.dispatchEvent(new Event('input')) // 初期値に対してもインジケーターが正しく表示されるようにするため、inputイベントを発火させる
 
     return textField

--- a/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/renameForm.ts
+++ b/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/renameForm.ts
@@ -14,6 +14,11 @@ export const TEXT_FIELD_ID = 'name-field'
 export const SEND_BUTTON_ID = 'name-send-button'
 
 /**
+ * 名前入力フォーム内にある文字数カウント要素のid
+ */
+export const RENAME_COUNT_ID = 'rename-count'
+
+/**
  * プレイヤー名変更欄
  */
 export class RenameForm {

--- a/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/renameForm.ts
+++ b/churaverse-plugins-client/src/playerPlugin/ui/playerSetting/renameForm.ts
@@ -19,6 +19,11 @@ export const SEND_BUTTON_ID = 'name-send-button'
 export const RENAME_COUNT_ID = 'rename-count'
 
 /**
+ * プレイヤー名の最大文字数
+ */
+const MAX_PLAYER_NAME_LENGTH = 15
+
+/**
  * プレイヤー名変更欄
  */
 export class RenameForm {
@@ -55,7 +60,7 @@ export class RenameForm {
     textField.oninput = () => {
       const count = textField.value.length
       if (countEl !== null) {
-        countEl.textContent = `${count}/15`
+        countEl.textContent = `${count}/${MAX_PLAYER_NAME_LENGTH}`
       }
     }
 
@@ -89,9 +94,9 @@ export class RenameForm {
   private validate(name: string): string[] {
     const errors: string[] = []
 
-    //名前の長さが15文字以下かを判定（全角・半角問わず）
-    if (name.length === 0 || name.length > 15) {
-      errors.push('名前は1文字以上15文字以下で入力してください')
+    //名前の長さがMAX_PLAYER_NAME_LENGTH文字以下かを判定（全角・半角問わず）
+    if (name.length === 0 || name.length > MAX_PLAYER_NAME_LENGTH) {
+      errors.push(`名前は1文字以上${MAX_PLAYER_NAME_LENGTH}文字以下で入力してください`)
     }
 
     //名前の途中で2つ以上の連続したスペースがあるかを判定

--- a/churaverse-plugins-client/src/titlePlugins/titleCoreUiPlugin/renderer/joinButtonRenderer.ts
+++ b/churaverse-plugins-client/src/titlePlugins/titleCoreUiPlugin/renderer/joinButtonRenderer.ts
@@ -87,7 +87,7 @@ export class JoinButtonRenderer implements IJoinButtonRenderer {
     if (errors.length > 0) {
       alert(errors.join('\n'))
       return
-    }else {
+    } else {
       // 処理が重複しないように処理中はボタンを押せないようにロック
       this.joinButton.disableInteractive()
 

--- a/churaverse-plugins-client/src/titlePlugins/titleCoreUiPlugin/renderer/joinButtonRenderer.ts
+++ b/churaverse-plugins-client/src/titlePlugins/titleCoreUiPlugin/renderer/joinButtonRenderer.ts
@@ -82,17 +82,18 @@ export class JoinButtonRenderer implements IJoinButtonRenderer {
 
   /** buttonが押されたときの動作 */
   private onClick(): void {
-    const validateResult = this.titlePlayerPluginStore.titleNameFieldRenderer.validate() ?? false
+    const errors = this.titlePlayerPluginStore.titleNameFieldRenderer.validate()
 
-    if (validateResult) {
+    if (errors.length > 0) {
+      alert(errors.join('\n'))
+      return
+    }else {
       // 処理が重複しないように処理中はボタンを押せないようにロック
       this.joinButton.disableInteractive()
 
       // MainSceneに遷移
       DomManager.removeAll()
       this.transitionPluginStore.transitionManager.transitionTo('MainScene')
-    } else {
-      alert('名前は1文字以上15文字以内で入力してください')
     }
   }
 }

--- a/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/domain/ITitleNameFieldRenderer.ts
+++ b/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/domain/ITitleNameFieldRenderer.ts
@@ -7,5 +7,5 @@ export interface ITitleNameFieldRenderer {
   /**
    * 名前に設定可能な文字列であるかの判定
    */
-  validate: () => boolean
+  validate: () => string[]
 }

--- a/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/domain/ITitleNameFieldRenderer.ts
+++ b/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/domain/ITitleNameFieldRenderer.ts
@@ -6,6 +6,7 @@ export interface ITitleNameFieldRenderer {
 
   /**
    * 名前に設定可能な文字列であるかの判定
+   * @return エラーメッセージの配列。エラーがない場合は空配列を返す。
    */
   validate: () => string[]
 }

--- a/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/components/TitleNameFieldComponent.tsx
+++ b/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/components/TitleNameFieldComponent.tsx
@@ -1,18 +1,22 @@
 import { JSXFunc } from 'churaverse-engine-client'
 import style from './titleNameFieldComponent.module.scss'
 
-export const TitleNameFieldComponent: JSXFunc = () => {
+interface TitleNameFieldProps {
+  maxLength: number
+}
+
+export const TitleNameFieldComponent: JSXFunc<TitleNameFieldProps> = ({ maxLength }) => {
   return (
     <div className={style.container}>
       <div className={style.inputWrapper}>
         <input className={style.textField} type="text" id="title-name-field" placeholder="Enter your name" />
         <div className={style.tooltip}>
           <ul>
-            <li>1文字以上15文字以下</li>
+            <li>1文字以上{maxLength}文字以下</li>
             <li>連続するスペースは使用不可</li>
           </ul>
         </div>
-        <span className={style.count} id="title-name-count">0/15</span>
+        <span className={style.count} id="title-name-count">0/{maxLength}</span>
       </div>
     </div>
   )

--- a/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/components/TitleNameFieldComponent.tsx
+++ b/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/components/TitleNameFieldComponent.tsx
@@ -12,13 +12,7 @@ export const TitleNameFieldComponent: JSXFunc = () => {
             <li>連続するスペースは使用不可</li>
           </ul>
         </div>
-      </div>
-      <div className={style.indicator}>
-        <svg viewBox="0 0 36 36" className={style.svg}>
-          <circle className={style.track} cx="18" cy="18" r="15.9" />
-          <circle className={style.meter} cx="18" cy="18" r="15.9" id="title-name-meter" />
-        </svg>
-        <span className={style.count} id="title-name-count">0</span>
+        <span className={style.count} id="title-name-count">0/15</span>
       </div>
     </div>
   )

--- a/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/components/TitleNameFieldComponent.tsx
+++ b/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/components/TitleNameFieldComponent.tsx
@@ -4,7 +4,22 @@ import style from './titleNameFieldComponent.module.scss'
 export const TitleNameFieldComponent: JSXFunc = () => {
   return (
     <div className={style.container}>
-      <input className={style.textField} type="text" id="title-name-field" placeholder="Enter your name" />
+      <div className={style.inputWrapper}>
+        <input className={style.textField} type="text" id="title-name-field" placeholder="Enter your name" />
+        <div className={style.tooltip}>
+          <ul>
+            <li>1文字以上15文字以下</li>
+            <li>連続するスペースは使用不可</li>
+          </ul>
+        </div>
+      </div>
+      <div className={style.indicator}>
+        <svg viewBox="0 0 36 36" className={style.svg}>
+          <circle className={style.track} cx="18" cy="18" r="15.9" />
+          <circle className={style.meter} cx="18" cy="18" r="15.9" id="title-name-meter" />
+        </svg>
+        <span className={style.count} id="title-name-count">0</span>
+      </div>
     </div>
   )
 }

--- a/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/components/titleNameFieldComponent.module.scss
+++ b/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/components/titleNameFieldComponent.module.scss
@@ -37,40 +37,11 @@
   display: block;
 }
 
-.indicator {
+.count {
   position: absolute;
   left: calc(100% + 8px);
   top: 50%;
   transform: translateY(-50%);
-  width: 40px;
-  height: 40px;
-}
-
-.svg {
-  width: 100%;
-  height: 100%;
-  transform: rotate(-90deg);
-}
-
-.track {
-  fill: none;
-  stroke: #ddd;
-  stroke-width: 3;
-}
-
-.meter {
-  fill: none;
-  stroke: #4caf50;
-  stroke-width: 3;
-  stroke-dasharray: 100;
-  stroke-dashoffset: 100;
-  transition: stroke-dashoffset 0.2s;
-}
-
-.count {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  font-size: 11px;
+  font-size: 15px;
+  white-space: nowrap;
 }

--- a/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/components/titleNameFieldComponent.module.scss
+++ b/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/components/titleNameFieldComponent.module.scss
@@ -25,7 +25,7 @@
   border-radius: 4px;
   padding: 6px 10px;
   white-space: nowrap;
-  z-index: 10;
+  text-align: left;
 
   ul {
     margin: 0;

--- a/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/components/titleNameFieldComponent.module.scss
+++ b/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/components/titleNameFieldComponent.module.scss
@@ -3,9 +3,6 @@
   left: 50%;
   top: 40%;
   transform: translate(-50%, -50%);
-  display: flex;
-  align-items: center;
-  gap: 8px;
 }
 
 .inputWrapper {
@@ -20,7 +17,7 @@
 .tooltip {
   display: none;
   position: absolute;
-  top: calc(100% + 4px);
+  bottom: calc(100% + 4px);
   left: 0;
   background: rgba(0, 0, 0, 0.75);
   color: #fff;
@@ -41,7 +38,10 @@
 }
 
 .indicator {
-  position: relative;
+  position: absolute;
+  left: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
   width: 40px;
   height: 40px;
 }

--- a/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/components/titleNameFieldComponent.module.scss
+++ b/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/components/titleNameFieldComponent.module.scss
@@ -3,9 +3,74 @@
   left: 50%;
   top: 40%;
   transform: translate(-50%, -50%);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.inputWrapper {
+  position: relative;
 }
 
 .textField {
   font-size: 15px;
   position: static;
+}
+
+.tooltip {
+  display: none;
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  background: rgba(0, 0, 0, 0.75);
+  color: #fff;
+  font-size: 12px;
+  border-radius: 4px;
+  padding: 6px 10px;
+  white-space: nowrap;
+  z-index: 10;
+
+  ul {
+    margin: 0;
+    padding-left: 16px;
+  }
+}
+
+.inputWrapper:hover .tooltip {
+  display: block;
+}
+
+.indicator {
+  position: relative;
+  width: 40px;
+  height: 40px;
+}
+
+.svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.track {
+  fill: none;
+  stroke: #ddd;
+  stroke-width: 3;
+}
+
+.meter {
+  fill: none;
+  stroke: #4caf50;
+  stroke-width: 3;
+  stroke-dasharray: 100;
+  stroke-dashoffset: 100;
+  transition: stroke-dashoffset 0.2s;
+}
+
+.count {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 11px;
 }

--- a/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/renderer/titleNameFieldRenderer.ts
+++ b/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/renderer/titleNameFieldRenderer.ts
@@ -13,11 +13,16 @@ export class TitleNameFieldRenderer implements ITitleNameFieldRenderer {
    * 名前入力欄
    */
   private readonly textField?: HTMLInputElement
+  private readonly meter: HTMLElement | null
+  private readonly countText: HTMLElement | null
 
   public constructor(private readonly eventBus: IEventBus<ITitleScene>) {
     // 名前入力欄の生成
     DomManager.addJsxDom(TitleNameFieldComponent())
     this.textField = DomManager.getElementById<HTMLInputElement>(TITLE_FIELD_NAME)
+    this.meter = document.getElementById('title-name-meter')
+    this.countText = document.getElementById('title-name-count')
+
     // 入力時の動作
     this.textField.oninput = () => {
       const changeNameEvent = new TitlePlayerNameChangeEvent(this.getName())
@@ -26,17 +31,16 @@ export class TitleNameFieldRenderer implements ITitleNameFieldRenderer {
       //インジケーター更新
       const count = (this.textField?.value ?? '').length
       const MAX_COUNT = 15
-      const meter = document.getElementById('title-name-meter')
-      const countText = document.getElementById('title-name-count')
-      if (meter !== null) {
+      if (this.meter !== null) {
         const offset = Math.max(0, 100 - (count / MAX_COUNT) * 100)
-        meter.style.strokeDashoffset = String(offset)
-        meter.style.stroke = count > MAX_COUNT ? '#f44336' : '#4caf50' 
+        this.meter.style.strokeDashoffset = String(offset)
+        this.meter.style.stroke = count > MAX_COUNT ? '#f44336' : '#4caf50' 
       }
-      if (countText !== null) {
-        countText.textContent = String(count)
+      if (this.countText !== null) {
+        this.countText.textContent = String(count)
       }
     }
+    this.textField.dispatchEvent(new Event('input')) // 初期値に対してもインジケーターが正しく表示されるようにするため、inputイベントを発火させる
   }
 
   public getName(): string {

--- a/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/renderer/titleNameFieldRenderer.ts
+++ b/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/renderer/titleNameFieldRenderer.ts
@@ -27,7 +27,7 @@ export class TitleNameFieldRenderer implements ITitleNameFieldRenderer {
 
   public constructor(private readonly eventBus: IEventBus<ITitleScene>) {
     // 名前入力欄の生成
-    DomManager.addJsxDom(TitleNameFieldComponent())
+    DomManager.addJsxDom(TitleNameFieldComponent({ maxLength: MAX_PLAYER_NAME_LENGTH }))
     this.textField = DomManager.getElementById<HTMLInputElement>(TITLE_FIELD_NAME)
     this.countText = document.getElementById(TITLE_NAME_COUNT_ID)
 

--- a/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/renderer/titleNameFieldRenderer.ts
+++ b/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/renderer/titleNameFieldRenderer.ts
@@ -8,39 +8,35 @@ import { TitleNameFieldComponent } from '../components/TitleNameFieldComponent'
  */
 const TITLE_FIELD_NAME = 'title-name-field'
 
+/**
+ * 名前入力フォーム内にある文字数カウント要素のid
+ */
+const TITLE_NAME_COUNT_ID = 'title-name-count'
+
 export class TitleNameFieldRenderer implements ITitleNameFieldRenderer {
   /**
    * 名前入力欄
    */
   private readonly textField?: HTMLInputElement
-  private readonly meter: HTMLElement | null
   private readonly countText: HTMLElement | null
 
   public constructor(private readonly eventBus: IEventBus<ITitleScene>) {
     // 名前入力欄の生成
     DomManager.addJsxDom(TitleNameFieldComponent())
     this.textField = DomManager.getElementById<HTMLInputElement>(TITLE_FIELD_NAME)
-    this.meter = document.getElementById('title-name-meter')
-    this.countText = document.getElementById('title-name-count')
+    this.countText = document.getElementById(TITLE_NAME_COUNT_ID)
 
     // 入力時の動作
     this.textField.oninput = () => {
       const changeNameEvent = new TitlePlayerNameChangeEvent(this.getName())
       this.eventBus.post(changeNameEvent)
 
-      //インジケーター更新
       const count = (this.textField?.value ?? '').length
-      const MAX_COUNT = 15
-      if (this.meter !== null) {
-        const offset = Math.max(0, 100 - (count / MAX_COUNT) * 100)
-        this.meter.style.strokeDashoffset = String(offset)
-        this.meter.style.stroke = count > MAX_COUNT ? '#f44336' : '#4caf50' 
-      }
       if (this.countText !== null) {
-        this.countText.textContent = String(count)
+        this.countText.textContent = `${count}/15`
       }
     }
-    this.textField.dispatchEvent(new Event('input')) // 初期値に対してもインジケーターが正しく表示されるようにするため、inputイベントを発火させる
+    this.textField.dispatchEvent(new Event('input')) // 初期値に対してもカウントが正しく表示されるようにするため、inputイベントを発火させる
   }
 
   public getName(): string {

--- a/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/renderer/titleNameFieldRenderer.ts
+++ b/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/renderer/titleNameFieldRenderer.ts
@@ -13,6 +13,11 @@ const TITLE_FIELD_NAME = 'title-name-field'
  */
 const TITLE_NAME_COUNT_ID = 'title-name-count'
 
+/**
+ * プレイヤー名の最大文字数
+ */
+const MAX_PLAYER_NAME_LENGTH = 15
+
 export class TitleNameFieldRenderer implements ITitleNameFieldRenderer {
   /**
    * 名前入力欄
@@ -33,7 +38,7 @@ export class TitleNameFieldRenderer implements ITitleNameFieldRenderer {
 
       const count = (this.textField?.value ?? '').length
       if (this.countText !== null) {
-        this.countText.textContent = `${count}/15`
+        this.countText.textContent = `${count}/${MAX_PLAYER_NAME_LENGTH}`
       }
     }
     this.textField.dispatchEvent(new Event('input')) // 初期値に対してもカウントが正しく表示されるようにするため、inputイベントを発火させる
@@ -46,9 +51,9 @@ export class TitleNameFieldRenderer implements ITitleNameFieldRenderer {
   public validate(): string[] {
     const name = this.getName()?.trim()
     const errors: string[] = []
-    //名前の長さが15文字以下かを判定（全角・半角問わず）
-    if (name.length === 0 || name.length > 15) {
-      errors.push('名前は1文字以上15文字以下で入力してください')
+    //名前の長さがMAX_PLAYER_NAME_LENGTH文字以下かを判定（全角・半角問わず）
+    if (name.length === 0 || name.length > MAX_PLAYER_NAME_LENGTH) {
+      errors.push(`名前は1文字以上${MAX_PLAYER_NAME_LENGTH}文字以下で入力してください`)
     }
     //名前の途中で2つ以上の連続したスペースがあるかを判定
     if (/\s{2,}/.test(name)) {

--- a/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/renderer/titleNameFieldRenderer.ts
+++ b/churaverse-plugins-client/src/titlePlugins/titlePlayerPlugin/ui/renderer/titleNameFieldRenderer.ts
@@ -22,6 +22,20 @@ export class TitleNameFieldRenderer implements ITitleNameFieldRenderer {
     this.textField.oninput = () => {
       const changeNameEvent = new TitlePlayerNameChangeEvent(this.getName())
       this.eventBus.post(changeNameEvent)
+
+      //インジケーター更新
+      const count = (this.textField?.value ?? '').length
+      const MAX_COUNT = 15
+      const meter = document.getElementById('title-name-meter')
+      const countText = document.getElementById('title-name-count')
+      if (meter !== null) {
+        const offset = Math.max(0, 100 - (count / MAX_COUNT) * 100)
+        meter.style.strokeDashoffset = String(offset)
+        meter.style.stroke = count > MAX_COUNT ? '#f44336' : '#4caf50' 
+      }
+      if (countText !== null) {
+        countText.textContent = String(count)
+      }
     }
   }
 
@@ -29,13 +43,17 @@ export class TitleNameFieldRenderer implements ITitleNameFieldRenderer {
     return this.textField?.value ?? ''
   }
 
-  public validate(): boolean {
+  public validate(): string[] {
     const name = this.getName()?.trim()
-    // 名前の文字列が空白文字のみまたは空文字のみでないかを判定
+    const errors: string[] = []
     //名前の長さが15文字以下かを判定（全角・半角問わず）
     if (name.length === 0 || name.length > 15) {
-      return false
+      errors.push('名前は1文字以上15文字以下で入力してください')
     }
-    return true
+    //名前の途中で2つ以上の連続したスペースがあるかを判定
+    if (/\s{2,}/.test(name)) {
+      errors.push('名前に連続したスペースを含めないでください')
+    }
+    return errors
   }
 }


### PR DESCRIPTION
CV-881のプレイヤー名入力によるレイアウト崩れの修正を行った。

- プレイヤー名に文字数制限と空白連続使用のバリデーションを付与
- ユーザが現在何文字入力しているかのレスポンスを実装

<img width="419" height="393" alt="スクリーンショット 2026-04-02 15 52 36" src="https://github.com/user-attachments/assets/d99cb398-65a2-4d9b-9573-14df120d293b" />
<img width="360" height="369" alt="スクリーンショット 2026-04-02 15 52 43" src="https://github.com/user-attachments/assets/cef05776-80ad-4639-95cc-9478944c5686" />
<img width="448" height="375" alt="スクリーンショット 2026-04-02 18 04 02" src="https://github.com/user-attachments/assets/a444a638-a274-4563-b45e-6f5e7d21a8af" />
