### PR TITLE
ちゅられんを中止するとボスが残るため、中止フローの中に描画の削除を追加

### DIFF
--- a/churaverse-plugins-client/src/churarenPlugin/churarenBossPlugin/churarenBossPlugin.ts
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenBossPlugin/churarenBossPlugin.ts
@@ -82,6 +82,9 @@ export class ChurarenBossPlugin extends BaseGamePlugin {
   }
 
   protected handleGameTermination(): void {
+    this.bossPluginStore?.bossRenderers.forEach((renderer) => {
+      renderer.destroy()
+    })
     resetBossPluginStore(this.store)
     this.socketController?.unregisterMessageListener()
   }


### PR DESCRIPTION
ちゅられんを中止ボタンからゲームをやめてしまうと、bossの描画が残ってしまうバグの修正

