### PR TITLE
インスタンス生成が複数回行われていたのでそれの削除

### DIFF
--- a/churaverse-plugins-server/src/churarenPlugin/churarenAlchemyPlugin/domain/baseAlchemyItemPlugin.ts
+++ b/churaverse-plugins-server/src/churarenPlugin/churarenAlchemyPlugin/domain/baseAlchemyItemPlugin.ts
@@ -14,12 +14,12 @@ export abstract class BaseAlchemyItemPlugin extends BaseGamePlugin {
 
   protected subscribeGameEvent(): void {
     super.subscribeGameEvent()
-    this.bus.subscribeEvent('alchemyItemRegister', this.onAlchemyItemRegister.bind(this))
+    this.bus.subscribeEvent('alchemyItemRegister', this.onAlchemyItemRegister)
   }
 
   protected unsubscribeGameEvent(): void {
     super.unsubscribeGameEvent()
-    this.bus.unsubscribeEvent('alchemyItemRegister', this.onAlchemyItemRegister.bind(this))
+    this.bus.unsubscribeEvent('alchemyItemRegister', this.onAlchemyItemRegister)
   }
 
   private readonly onAlchemyItemRegister = (ev: AlchemyItemRegisterEvent): void => {


### PR DESCRIPTION
- バグ状況
ちゅられんを複数回中止すると、ドラゴンが攻撃しなくなるバグが発生

- 原因
アイテム側でインスタンス生成を複数回行っており、それによって削除が間に合わずエラー発生。それによりイベントが発行されず攻撃メソッドが呼び出されない