### PR TITLE
tornadoの生成必要アイテム数を緑鉱石2つから3つに変更

### DIFF
--- a/churaverse-plugins-server/src/churarenPlugin/churarenAlchemyItems/tornadoPlugin/domain/tornado.ts
+++ b/churaverse-plugins-server/src/churarenPlugin/churarenAlchemyItems/tornadoPlugin/domain/tornado.ts
@@ -12,7 +12,7 @@ const totalSteps = 10
 export const TORNADO_ITEM: IAlchemyItem = {
   kind: 'tornado',
   recipe: {
-    pattern: 'two_same_one_diff',
+    pattern: 'all_same',
     materialKind: 'grassOre',
   },
 }


### PR DESCRIPTION
- バグ状況
攻撃手段であるトルネードが仕様書では本来、緑鉱石3つで生成なのに2つでも生成できてしまっていた。

- 原因
生成の時に2つで可能なようにしていたのでそこを修正