### PR TITLE
copyAssetsToDist.shでnode_modulesがdistに含まれないように修正

### DIFF
--- a/churaverse-plugins-client/copyAssetsToDist.sh
+++ b/churaverse-plugins-client/copyAssetsToDist.sh
@@ -1,40 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# コピー元の基本パス
-src_base="src"
-# コピー先の基本パス
-dest_base="dist"
+# ================================
+# rsyncで excludeパターンをリスト管理して dist にコピーする例
+# ================================
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type d -name 'assets' | while read src_dir; do
-    # 対応するコピー先のディレクトリパスを生成
-    dest_dir="${src_dir/$src_base/$dest_base}"
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp -r "$src_dir/"* "$dest_dir"
+# 除外パターンをリスト(配列)で管理
+EXCLUDE_LIST=(
+  "dist"
+  "node_modules"
+  ".git"
+  "*.ts"
+  "*.tsx"
+  "*.js"
+  # "*.d.ts" # matched by *.ts
+)
+
+# rsync に渡すオプション配列を定義
+RSYNC_OPTS=(-av)
+
+# EXCLUDE_LIST にある除外パターンを
+# 1つずつ --exclude オプションに追加していく
+for pattern in "${EXCLUDE_LIST[@]}"; do
+  RSYNC_OPTS+=("--exclude=$pattern")
 done
 
-echo "assetsコピー完了"
+# 最終的に rsync を実行
+# 例: rsync -av --exclude=dist --exclude=node_modules ... . dist/
+rsync "${RSYNC_OPTS[@]}" . dist/
 
-#!/bin/bash
-
-# コピー元の基本パス
-src_base="src"
-# コピー先の基本パス
-dest_base="dist"
-
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type f -name '*.scss' | while read src_file; do
-    # 対応するコピー先のファイルパスを生成
-    dest_file="${src_file/$src_base/$dest_base}"
-    # コピー先のディレクトリを取得
-    dest_dir=$(dirname "$dest_file")
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp "$src_file" "$dest_file"
-done
-
-echo "コピー完了"
-
+echo "=== copy assets finished ==="

--- a/churaverse-plugins-client/src/bombPlugin/copyAssetsToDist.sh
+++ b/churaverse-plugins-client/src/bombPlugin/copyAssetsToDist.sh
@@ -1,41 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# コピー元の基本パス
-src_base="."
-# コピー先の基本パス
-dest_base="dist"
+# ================================
+# rsyncで excludeパターンをリスト管理して dist にコピーする例
+# ================================
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type d -name 'assets' | while read src_dir; do
-    # 対応するコピー先のディレクトリパスを生成
-    dest_dir="${src_dir/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_dir" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp -r "$src_dir/"* "$dest_dir"
+# 除外パターンをリスト(配列)で管理
+EXCLUDE_LIST=(
+  "dist"
+  "node_modules"
+  ".git"
+  "*.ts"
+  "*.tsx"
+  "*.js"
+  # "*.d.ts" # matched by *.ts
+)
+
+# rsync に渡すオプション配列を定義
+RSYNC_OPTS=(-av)
+
+# EXCLUDE_LIST にある除外パターンを
+# 1つずつ --exclude オプションに追加していく
+for pattern in "${EXCLUDE_LIST[@]}"; do
+  RSYNC_OPTS+=("--exclude=$pattern")
 done
 
-echo "copied asset files"
+# 最終的に rsync を実行
+# 例: rsync -av --exclude=dist --exclude=node_modules ... . dist/
+rsync "${RSYNC_OPTS[@]}" . dist/
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type f -name '*.scss' | while read src_file; do
-    # 対応するコピー先のファイルパスを生成
-    dest_file="${src_file/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_file" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリを取得
-    dest_dir=$(dirname "$dest_file")
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp "$src_file" "$dest_file"
-done
-
-echo "コピー完了"
-
+echo "=== copy assets finished ==="

--- a/churaverse-plugins-client/src/cameraVideoChatPlugin/copyAssetsToDist.sh
+++ b/churaverse-plugins-client/src/cameraVideoChatPlugin/copyAssetsToDist.sh
@@ -1,41 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# コピー元の基本パス
-src_base="."
-# コピー先の基本パス
-dest_base="dist"
+# ================================
+# rsyncで excludeパターンをリスト管理して dist にコピーする例
+# ================================
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type d -name 'assets' | while read src_dir; do
-    # 対応するコピー先のディレクトリパスを生成
-    dest_dir="${src_dir/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_dir" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp -r "$src_dir/"* "$dest_dir"
+# 除外パターンをリスト(配列)で管理
+EXCLUDE_LIST=(
+  "dist"
+  "node_modules"
+  ".git"
+  "*.ts"
+  "*.tsx"
+  "*.js"
+  # "*.d.ts" # matched by *.ts
+)
+
+# rsync に渡すオプション配列を定義
+RSYNC_OPTS=(-av)
+
+# EXCLUDE_LIST にある除外パターンを
+# 1つずつ --exclude オプションに追加していく
+for pattern in "${EXCLUDE_LIST[@]}"; do
+  RSYNC_OPTS+=("--exclude=$pattern")
 done
 
-echo "copied asset files"
+# 最終的に rsync を実行
+# 例: rsync -av --exclude=dist --exclude=node_modules ... . dist/
+rsync "${RSYNC_OPTS[@]}" . dist/
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type f -name '*.scss' | while read src_file; do
-    # 対応するコピー先のファイルパスを生成
-    dest_file="${src_file/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_file" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリを取得
-    dest_dir=$(dirname "$dest_file")
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp "$src_file" "$dest_file"
-done
-
-echo "コピー完了"
-
+echo "=== copy assets finished ==="

--- a/churaverse-plugins-client/src/coreUiPlugin/copyAssetsToDist.sh
+++ b/churaverse-plugins-client/src/coreUiPlugin/copyAssetsToDist.sh
@@ -1,41 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# コピー元の基本パス
-src_base="."
-# コピー先の基本パス
-dest_base="dist"
+# ================================
+# rsyncで excludeパターンをリスト管理して dist にコピーする例
+# ================================
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type d -name 'assets' | while read src_dir; do
-    # 対応するコピー先のディレクトリパスを生成
-    dest_dir="${src_dir/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_dir" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp -r "$src_dir/"* "$dest_dir"
+# 除外パターンをリスト(配列)で管理
+EXCLUDE_LIST=(
+  "dist"
+  "node_modules"
+  ".git"
+  "*.ts"
+  "*.tsx"
+  "*.js"
+  # "*.d.ts" # matched by *.ts
+)
+
+# rsync に渡すオプション配列を定義
+RSYNC_OPTS=(-av)
+
+# EXCLUDE_LIST にある除外パターンを
+# 1つずつ --exclude オプションに追加していく
+for pattern in "${EXCLUDE_LIST[@]}"; do
+  RSYNC_OPTS+=("--exclude=$pattern")
 done
 
-echo "copied asset files"
+# 最終的に rsync を実行
+# 例: rsync -av --exclude=dist --exclude=node_modules ... . dist/
+rsync "${RSYNC_OPTS[@]}" . dist/
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type f -name '*.scss' | while read src_file; do
-    # 対応するコピー先のファイルパスを生成
-    dest_file="${src_file/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_file" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリを取得
-    dest_dir=$(dirname "$dest_file")
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp "$src_file" "$dest_file"
-done
-
-echo "コピー完了"
-
+echo "=== copy assets finished ==="

--- a/churaverse-plugins-client/src/debugScreenPlugin/copyAssetsToDist.sh
+++ b/churaverse-plugins-client/src/debugScreenPlugin/copyAssetsToDist.sh
@@ -1,41 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# コピー元の基本パス
-src_base="."
-# コピー先の基本パス
-dest_base="dist"
+# ================================
+# rsyncで excludeパターンをリスト管理して dist にコピーする例
+# ================================
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type d -name 'assets' | while read src_dir; do
-    # 対応するコピー先のディレクトリパスを生成
-    dest_dir="${src_dir/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_dir" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp -r "$src_dir/"* "$dest_dir"
+# 除外パターンをリスト(配列)で管理
+EXCLUDE_LIST=(
+  "dist"
+  "node_modules"
+  ".git"
+  "*.ts"
+  "*.tsx"
+  "*.js"
+  # "*.d.ts" # matched by *.ts
+)
+
+# rsync に渡すオプション配列を定義
+RSYNC_OPTS=(-av)
+
+# EXCLUDE_LIST にある除外パターンを
+# 1つずつ --exclude オプションに追加していく
+for pattern in "${EXCLUDE_LIST[@]}"; do
+  RSYNC_OPTS+=("--exclude=$pattern")
 done
 
-echo "copied asset files"
+# 最終的に rsync を実行
+# 例: rsync -av --exclude=dist --exclude=node_modules ... . dist/
+rsync "${RSYNC_OPTS[@]}" . dist/
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type f -name '*.scss' | while read src_file; do
-    # 対応するコピー先のファイルパスを生成
-    dest_file="${src_file/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_file" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリを取得
-    dest_dir=$(dirname "$dest_file")
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp "$src_file" "$dest_file"
-done
-
-echo "コピー完了"
-
+echo "=== copy assets finished ==="

--- a/churaverse-plugins-client/src/gamePlugin/copyAssetsToDist.sh
+++ b/churaverse-plugins-client/src/gamePlugin/copyAssetsToDist.sh
@@ -1,41 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# コピー元の基本パス
-src_base="."
-# コピー先の基本パス
-dest_base="dist"
+# ================================
+# rsyncで excludeパターンをリスト管理して dist にコピーする例
+# ================================
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type d -name 'assets' | while read src_dir; do
-    # 対応するコピー先のディレクトリパスを生成
-    dest_dir="${src_dir/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_dir" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp -r "$src_dir/"* "$dest_dir"
+# 除外パターンをリスト(配列)で管理
+EXCLUDE_LIST=(
+  "dist"
+  "node_modules"
+  ".git"
+  "*.ts"
+  "*.tsx"
+  "*.js"
+  # "*.d.ts" # matched by *.ts
+)
+
+# rsync に渡すオプション配列を定義
+RSYNC_OPTS=(-av)
+
+# EXCLUDE_LIST にある除外パターンを
+# 1つずつ --exclude オプションに追加していく
+for pattern in "${EXCLUDE_LIST[@]}"; do
+  RSYNC_OPTS+=("--exclude=$pattern")
 done
 
-echo "copied asset files"
+# 最終的に rsync を実行
+# 例: rsync -av --exclude=dist --exclude=node_modules ... . dist/
+rsync "${RSYNC_OPTS[@]}" . dist/
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type f -name '*.scss' | while read src_file; do
-    # 対応するコピー先のファイルパスを生成
-    dest_file="${src_file/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_file" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリを取得
-    dest_dir=$(dirname "$dest_file")
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp "$src_file" "$dest_file"
-done
-
-echo "コピー完了"
-
+echo "=== copy assets finished ==="

--- a/churaverse-plugins-client/src/keyboardPlugin/copyAssetsToDist.sh
+++ b/churaverse-plugins-client/src/keyboardPlugin/copyAssetsToDist.sh
@@ -1,41 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# コピー元の基本パス
-src_base="."
-# コピー先の基本パス
-dest_base="dist"
+# ================================
+# rsyncで excludeパターンをリスト管理して dist にコピーする例
+# ================================
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type d -name 'assets' | while read src_dir; do
-    # 対応するコピー先のディレクトリパスを生成
-    dest_dir="${src_dir/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_dir" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp -r "$src_dir/"* "$dest_dir"
+# 除外パターンをリスト(配列)で管理
+EXCLUDE_LIST=(
+  "dist"
+  "node_modules"
+  ".git"
+  "*.ts"
+  "*.tsx"
+  "*.js"
+  # "*.d.ts" # matched by *.ts
+)
+
+# rsync に渡すオプション配列を定義
+RSYNC_OPTS=(-av)
+
+# EXCLUDE_LIST にある除外パターンを
+# 1つずつ --exclude オプションに追加していく
+for pattern in "${EXCLUDE_LIST[@]}"; do
+  RSYNC_OPTS+=("--exclude=$pattern")
 done
 
-echo "copied asset files"
+# 最終的に rsync を実行
+# 例: rsync -av --exclude=dist --exclude=node_modules ... . dist/
+rsync "${RSYNC_OPTS[@]}" . dist/
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type f -name '*.scss' | while read src_file; do
-    # 対応するコピー先のファイルパスを生成
-    dest_file="${src_file/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_file" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリを取得
-    dest_dir=$(dirname "$dest_file")
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp "$src_file" "$dest_file"
-done
-
-echo "コピー完了"
-
+echo "=== copy assets finished ==="

--- a/churaverse-plugins-client/src/kickPlugin/copyAssetsToDist.sh
+++ b/churaverse-plugins-client/src/kickPlugin/copyAssetsToDist.sh
@@ -1,41 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# コピー元の基本パス
-src_base="."
-# コピー先の基本パス
-dest_base="dist"
+# ================================
+# rsyncで excludeパターンをリスト管理して dist にコピーする例
+# ================================
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type d -name 'assets' | while read src_dir; do
-    # 対応するコピー先のディレクトリパスを生成
-    dest_dir="${src_dir/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_dir" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp -r "$src_dir/"* "$dest_dir"
+# 除外パターンをリスト(配列)で管理
+EXCLUDE_LIST=(
+  "dist"
+  "node_modules"
+  ".git"
+  "*.ts"
+  "*.tsx"
+  "*.js"
+  # "*.d.ts" # matched by *.ts
+)
+
+# rsync に渡すオプション配列を定義
+RSYNC_OPTS=(-av)
+
+# EXCLUDE_LIST にある除外パターンを
+# 1つずつ --exclude オプションに追加していく
+for pattern in "${EXCLUDE_LIST[@]}"; do
+  RSYNC_OPTS+=("--exclude=$pattern")
 done
 
-echo "copied asset files"
+# 最終的に rsync を実行
+# 例: rsync -av --exclude=dist --exclude=node_modules ... . dist/
+rsync "${RSYNC_OPTS[@]}" . dist/
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type f -name '*.scss' | while read src_file; do
-    # 対応するコピー先のファイルパスを生成
-    dest_file="${src_file/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_file" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリを取得
-    dest_dir=$(dirname "$dest_file")
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp "$src_file" "$dest_file"
-done
-
-echo "コピー完了"
-
+echo "=== copy assets finished ==="

--- a/churaverse-plugins-client/src/mapPlugin/copyAssetsToDist.sh
+++ b/churaverse-plugins-client/src/mapPlugin/copyAssetsToDist.sh
@@ -1,41 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# コピー元の基本パス
-src_base="."
-# コピー先の基本パス
-dest_base="dist"
+# ================================
+# rsyncで excludeパターンをリスト管理して dist にコピーする例
+# ================================
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type d -name 'assets' | while read src_dir; do
-    # 対応するコピー先のディレクトリパスを生成
-    dest_dir="${src_dir/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_dir" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp -r "$src_dir/"* "$dest_dir"
+# 除外パターンをリスト(配列)で管理
+EXCLUDE_LIST=(
+  "dist"
+  "node_modules"
+  ".git"
+  "*.ts"
+  "*.tsx"
+  "*.js"
+  # "*.d.ts" # matched by *.ts
+)
+
+# rsync に渡すオプション配列を定義
+RSYNC_OPTS=(-av)
+
+# EXCLUDE_LIST にある除外パターンを
+# 1つずつ --exclude オプションに追加していく
+for pattern in "${EXCLUDE_LIST[@]}"; do
+  RSYNC_OPTS+=("--exclude=$pattern")
 done
 
-echo "copied asset files"
+# 最終的に rsync を実行
+# 例: rsync -av --exclude=dist --exclude=node_modules ... . dist/
+rsync "${RSYNC_OPTS[@]}" . dist/
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type f -name '*.scss' | while read src_file; do
-    # 対応するコピー先のファイルパスを生成
-    dest_file="${src_file/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_file" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリを取得
-    dest_dir=$(dirname "$dest_file")
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp "$src_file" "$dest_file"
-done
-
-echo "コピー完了"
-
+echo "=== copy assets finished ==="

--- a/churaverse-plugins-client/src/playerListPlugin/copyAssetsToDist.sh
+++ b/churaverse-plugins-client/src/playerListPlugin/copyAssetsToDist.sh
@@ -1,41 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# コピー元の基本パス
-src_base="."
-# コピー先の基本パス
-dest_base="dist"
+# ================================
+# rsyncで excludeパターンをリスト管理して dist にコピーする例
+# ================================
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type d -name 'assets' | while read src_dir; do
-    # 対応するコピー先のディレクトリパスを生成
-    dest_dir="${src_dir/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_dir" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp -r "$src_dir/"* "$dest_dir"
+# 除外パターンをリスト(配列)で管理
+EXCLUDE_LIST=(
+  "dist"
+  "node_modules"
+  ".git"
+  "*.ts"
+  "*.tsx"
+  "*.js"
+  # "*.d.ts" # matched by *.ts
+)
+
+# rsync に渡すオプション配列を定義
+RSYNC_OPTS=(-av)
+
+# EXCLUDE_LIST にある除外パターンを
+# 1つずつ --exclude オプションに追加していく
+for pattern in "${EXCLUDE_LIST[@]}"; do
+  RSYNC_OPTS+=("--exclude=$pattern")
 done
 
-echo "copied asset files"
+# 最終的に rsync を実行
+# 例: rsync -av --exclude=dist --exclude=node_modules ... . dist/
+rsync "${RSYNC_OPTS[@]}" . dist/
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type f -name '*.scss' | while read src_file; do
-    # 対応するコピー先のファイルパスを生成
-    dest_file="${src_file/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_file" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリを取得
-    dest_dir=$(dirname "$dest_file")
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp "$src_file" "$dest_file"
-done
-
-echo "コピー完了"
-
+echo "=== copy assets finished ==="

--- a/churaverse-plugins-client/src/playerPlugin/copyAssetsToDist.sh
+++ b/churaverse-plugins-client/src/playerPlugin/copyAssetsToDist.sh
@@ -1,41 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# コピー元の基本パス
-src_base="."
-# コピー先の基本パス
-dest_base="dist"
+# ================================
+# rsyncで excludeパターンをリスト管理して dist にコピーする例
+# ================================
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type d -name 'assets' | while read src_dir; do
-    # 対応するコピー先のディレクトリパスを生成
-    dest_dir="${src_dir/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_dir" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp -r "$src_dir/"* "$dest_dir"
+# 除外パターンをリスト(配列)で管理
+EXCLUDE_LIST=(
+  "dist"
+  "node_modules"
+  ".git"
+  "*.ts"
+  "*.tsx"
+  "*.js"
+  # "*.d.ts" # matched by *.ts
+)
+
+# rsync に渡すオプション配列を定義
+RSYNC_OPTS=(-av)
+
+# EXCLUDE_LIST にある除外パターンを
+# 1つずつ --exclude オプションに追加していく
+for pattern in "${EXCLUDE_LIST[@]}"; do
+  RSYNC_OPTS+=("--exclude=$pattern")
 done
 
-echo "copied asset files"
+# 最終的に rsync を実行
+# 例: rsync -av --exclude=dist --exclude=node_modules ... . dist/
+rsync "${RSYNC_OPTS[@]}" . dist/
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type f -name '*.scss' | while read src_file; do
-    # 対応するコピー先のファイルパスを生成
-    dest_file="${src_file/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_file" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリを取得
-    dest_dir=$(dirname "$dest_file")
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp "$src_file" "$dest_file"
-done
-
-echo "コピー完了"
-
+echo "=== copy assets finished ==="

--- a/churaverse-plugins-client/src/screenSharePlugin/copyAssetsToDist.sh
+++ b/churaverse-plugins-client/src/screenSharePlugin/copyAssetsToDist.sh
@@ -1,41 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# コピー元の基本パス
-src_base="."
-# コピー先の基本パス
-dest_base="dist"
+# ================================
+# rsyncで excludeパターンをリスト管理して dist にコピーする例
+# ================================
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type d -name 'assets' | while read src_dir; do
-    # 対応するコピー先のディレクトリパスを生成
-    dest_dir="${src_dir/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_dir" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp -r "$src_dir/"* "$dest_dir"
+# 除外パターンをリスト(配列)で管理
+EXCLUDE_LIST=(
+  "dist"
+  "node_modules"
+  ".git"
+  "*.ts"
+  "*.tsx"
+  "*.js"
+  # "*.d.ts" # matched by *.ts
+)
+
+# rsync に渡すオプション配列を定義
+RSYNC_OPTS=(-av)
+
+# EXCLUDE_LIST にある除外パターンを
+# 1つずつ --exclude オプションに追加していく
+for pattern in "${EXCLUDE_LIST[@]}"; do
+  RSYNC_OPTS+=("--exclude=$pattern")
 done
 
-echo "copied asset files"
+# 最終的に rsync を実行
+# 例: rsync -av --exclude=dist --exclude=node_modules ... . dist/
+rsync "${RSYNC_OPTS[@]}" . dist/
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type f -name '*.scss' | while read src_file; do
-    # 対応するコピー先のファイルパスを生成
-    dest_file="${src_file/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_file" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリを取得
-    dest_dir=$(dirname "$dest_file")
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp "$src_file" "$dest_file"
-done
-
-echo "コピー完了"
-
+echo "=== copy assets finished ==="

--- a/churaverse-plugins-client/src/sharkPlugin/copyAssetsToDist.sh
+++ b/churaverse-plugins-client/src/sharkPlugin/copyAssetsToDist.sh
@@ -1,41 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# コピー元の基本パス
-src_base="."
-# コピー先の基本パス
-dest_base="dist"
+# ================================
+# rsyncで excludeパターンをリスト管理して dist にコピーする例
+# ================================
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type d -name 'assets' | while read src_dir; do
-    # 対応するコピー先のディレクトリパスを生成
-    dest_dir="${src_dir/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_dir" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp -r "$src_dir/"* "$dest_dir"
+# 除外パターンをリスト(配列)で管理
+EXCLUDE_LIST=(
+  "dist"
+  "node_modules"
+  ".git"
+  "*.ts"
+  "*.tsx"
+  "*.js"
+  # "*.d.ts" # matched by *.ts
+)
+
+# rsync に渡すオプション配列を定義
+RSYNC_OPTS=(-av)
+
+# EXCLUDE_LIST にある除外パターンを
+# 1つずつ --exclude オプションに追加していく
+for pattern in "${EXCLUDE_LIST[@]}"; do
+  RSYNC_OPTS+=("--exclude=$pattern")
 done
 
-echo "copied asset files"
+# 最終的に rsync を実行
+# 例: rsync -av --exclude=dist --exclude=node_modules ... . dist/
+rsync "${RSYNC_OPTS[@]}" . dist/
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type f -name '*.scss' | while read src_file; do
-    # 対応するコピー先のファイルパスを生成
-    dest_file="${src_file/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_file" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリを取得
-    dest_dir=$(dirname "$dest_file")
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp "$src_file" "$dest_file"
-done
-
-echo "コピー完了"
-
+echo "=== copy assets finished ==="

--- a/churaverse-plugins-client/src/textChatPlugin/copyAssetsToDist.sh
+++ b/churaverse-plugins-client/src/textChatPlugin/copyAssetsToDist.sh
@@ -1,41 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# コピー元の基本パス
-src_base="."
-# コピー先の基本パス
-dest_base="dist"
+# ================================
+# rsyncで excludeパターンをリスト管理して dist にコピーする例
+# ================================
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type d -name 'assets' | while read src_dir; do
-    # 対応するコピー先のディレクトリパスを生成
-    dest_dir="${src_dir/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_dir" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp -r "$src_dir/"* "$dest_dir"
+# 除外パターンをリスト(配列)で管理
+EXCLUDE_LIST=(
+  "dist"
+  "node_modules"
+  ".git"
+  "*.ts"
+  "*.tsx"
+  "*.js"
+  # "*.d.ts" # matched by *.ts
+)
+
+# rsync に渡すオプション配列を定義
+RSYNC_OPTS=(-av)
+
+# EXCLUDE_LIST にある除外パターンを
+# 1つずつ --exclude オプションに追加していく
+for pattern in "${EXCLUDE_LIST[@]}"; do
+  RSYNC_OPTS+=("--exclude=$pattern")
 done
 
-echo "copied asset files"
+# 最終的に rsync を実行
+# 例: rsync -av --exclude=dist --exclude=node_modules ... . dist/
+rsync "${RSYNC_OPTS[@]}" . dist/
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type f -name '*.scss' | while read src_file; do
-    # 対応するコピー先のファイルパスを生成
-    dest_file="${src_file/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_file" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリを取得
-    dest_dir=$(dirname "$dest_file")
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp "$src_file" "$dest_file"
-done
-
-echo "コピー完了"
-
+echo "=== copy assets finished ==="

--- a/churaverse-plugins-client/src/titlePlugins/copyAssetsToDist.sh
+++ b/churaverse-plugins-client/src/titlePlugins/copyAssetsToDist.sh
@@ -1,41 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# コピー元の基本パス
-src_base="."
-# コピー先の基本パス
-dest_base="dist"
+# ================================
+# rsyncで excludeパターンをリスト管理して dist にコピーする例
+# ================================
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type d -name 'assets' | while read src_dir; do
-    # 対応するコピー先のディレクトリパスを生成
-    dest_dir="${src_dir/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_dir" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp -r "$src_dir/"* "$dest_dir"
+# 除外パターンをリスト(配列)で管理
+EXCLUDE_LIST=(
+  "dist"
+  "node_modules"
+  ".git"
+  "*.ts"
+  "*.tsx"
+  "*.js"
+  # "*.d.ts" # matched by *.ts
+)
+
+# rsync に渡すオプション配列を定義
+RSYNC_OPTS=(-av)
+
+# EXCLUDE_LIST にある除外パターンを
+# 1つずつ --exclude オプションに追加していく
+for pattern in "${EXCLUDE_LIST[@]}"; do
+  RSYNC_OPTS+=("--exclude=$pattern")
 done
 
-echo "copied asset files"
+# 最終的に rsync を実行
+# 例: rsync -av --exclude=dist --exclude=node_modules ... . dist/
+rsync "${RSYNC_OPTS[@]}" . dist/
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type f -name '*.scss' | while read src_file; do
-    # 対応するコピー先のファイルパスを生成
-    dest_file="${src_file/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_file" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリを取得
-    dest_dir=$(dirname "$dest_file")
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp "$src_file" "$dest_file"
-done
-
-echo "コピー完了"
-
+echo "=== copy assets finished ==="

--- a/churaverse-plugins-client/src/voiceChatPlugin/copyAssetsToDist.sh
+++ b/churaverse-plugins-client/src/voiceChatPlugin/copyAssetsToDist.sh
@@ -1,41 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# コピー元の基本パス
-src_base="."
-# コピー先の基本パス
-dest_base="dist"
+# ================================
+# rsyncで excludeパターンをリスト管理して dist にコピーする例
+# ================================
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type d -name 'assets' | while read src_dir; do
-    # 対応するコピー先のディレクトリパスを生成
-    dest_dir="${src_dir/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_dir" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp -r "$src_dir/"* "$dest_dir"
+# 除外パターンをリスト(配列)で管理
+EXCLUDE_LIST=(
+  "dist"
+  "node_modules"
+  ".git"
+  "*.ts"
+  "*.tsx"
+  "*.js"
+  # "*.d.ts" # matched by *.ts
+)
+
+# rsync に渡すオプション配列を定義
+RSYNC_OPTS=(-av)
+
+# EXCLUDE_LIST にある除外パターンを
+# 1つずつ --exclude オプションに追加していく
+for pattern in "${EXCLUDE_LIST[@]}"; do
+  RSYNC_OPTS+=("--exclude=$pattern")
 done
 
-echo "copied asset files"
+# 最終的に rsync を実行
+# 例: rsync -av --exclude=dist --exclude=node_modules ... . dist/
+rsync "${RSYNC_OPTS[@]}" . dist/
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type f -name '*.scss' | while read src_file; do
-    # 対応するコピー先のファイルパスを生成
-    dest_file="${src_file/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_file" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリを取得
-    dest_dir=$(dirname "$dest_file")
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp "$src_file" "$dest_file"
-done
-
-echo "コピー完了"
-
+echo "=== copy assets finished ==="

--- a/churaverse-plugins-client/src/webRtcPlugin/copyAssetsToDist.sh
+++ b/churaverse-plugins-client/src/webRtcPlugin/copyAssetsToDist.sh
@@ -1,41 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# コピー元の基本パス
-src_base="."
-# コピー先の基本パス
-dest_base="dist"
+# ================================
+# rsyncで excludeパターンをリスト管理して dist にコピーする例
+# ================================
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type d -name 'assets' | while read src_dir; do
-    # 対応するコピー先のディレクトリパスを生成
-    dest_dir="${src_dir/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_dir" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp -r "$src_dir/"* "$dest_dir"
+# 除外パターンをリスト(配列)で管理
+EXCLUDE_LIST=(
+  "dist"
+  "node_modules"
+  ".git"
+  "*.ts"
+  "*.tsx"
+  "*.js"
+  # "*.d.ts" # matched by *.ts
+)
+
+# rsync に渡すオプション配列を定義
+RSYNC_OPTS=(-av)
+
+# EXCLUDE_LIST にある除外パターンを
+# 1つずつ --exclude オプションに追加していく
+for pattern in "${EXCLUDE_LIST[@]}"; do
+  RSYNC_OPTS+=("--exclude=$pattern")
 done
 
-echo "copied asset files"
+# 最終的に rsync を実行
+# 例: rsync -av --exclude=dist --exclude=node_modules ... . dist/
+rsync "${RSYNC_OPTS[@]}" . dist/
 
-# コピー元のパスを検索し、それぞれに対して処理を実行
-find "$src_base" -type f -name '*.scss' | while read src_file; do
-    # 対応するコピー先のファイルパスを生成
-    dest_file="${src_file/$src_base/$dest_base}"
-    # コピー元が dest_base ならスキップする処理
-    if [[ "$src_file" == *"$dest_base"* ]]; then
-        continue
-    fi
-    # コピー先のディレクトリを取得
-    dest_dir=$(dirname "$dest_file")
-    # コピー先のディレクトリがなければ作成
-    mkdir -p "$dest_dir"
-    # ファイルをコピー先にコピー
-    cp "$src_file" "$dest_file"
-done
-
-echo "コピー完了"
-
+echo "=== copy assets finished ==="


### PR DESCRIPTION
# 概要
copyAssetsToDist.sh を修正する。
copyAssetsToDist.sh に関しては、`npm run build`を実行した際に、コンパイラされない、`.png`, `.scss`などのアセットファイルを dist/ に シェル経由でファイルをコピーするファイルである。
しかし、現状だと、node_modules/ 内のファイルまでdist にコピーさせてしまい、不要なファイルも含まれている現状である。
そのため、本PRでは、その箇所を修正する。ただ、synchroBreakPlugin では、すでに対応策が実装されていたため、その実装を踏襲する形で他のプラグインを修正する。

チケットへのリンク：https://churadata.backlog.com/view/CV-918

## 変更内容

- copyAssetToDist.sh の修正を行う

## 補足
なし

## チェックリスト
- [x] 最新の master ブランチを作業ブランチに取り込んでいますか？
- [x] 最後に Push したその状態は動作確認をしていますか？
- [x] File changed は確認しましたか？
  - print デバッグなどで使用した print 文や log 出力は消しましたか？
  - 不必要なメモや使わなくなったコード残していないですか？
  - 意図していない変更や修正が含まれていないですか？
  - 第三者が見てよくわからない命名などになっていませんか？
- [x] マージできる状態になっていますか？
  - コンフリクトは起きていないですか？
  - まだ作業する必要があるタスクがあるため、このブランチにマージをしていきます。

