### PR TITLE
Fix/cv 919/alchemy item always produces black hole

### DIFF
--- a/churaverse-plugins-client/src/churarenPlugin/churarenAlchemyItems/blackHolePlugin/blackHolePlugin.ts
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenAlchemyItems/blackHolePlugin/blackHolePlugin.ts
@@ -90,7 +90,7 @@ export class BlackHolePlugin extends BaseAlchemyItemPlugin {
     resetBlackHolePluginStore(this.store)
   }
 
-  protected handleMidwayParticipant(): void {
+  protected handleMidwayJoin(): void {
     this.unsubscribeGameEvent()
   }
 

--- a/churaverse-plugins-server/src/churarenPlugin/churarenAlchemyPlugin/domain/baseAlchemyItemPlugin.ts
+++ b/churaverse-plugins-server/src/churarenPlugin/churarenAlchemyPlugin/domain/baseAlchemyItemPlugin.ts
@@ -12,14 +12,17 @@ export abstract class BaseAlchemyItemPlugin extends BaseGamePlugin {
   public gameId = CHURAREN_CONSTANTS.GAME_ID
   protected abstract alchemyItem: IAlchemyItem
 
+  public listenEvent(): void {
+    super.listenEvent()
+    this.bus.subscribeEvent('alchemyItemRegister', this.onAlchemyItemRegister)
+  }
+
   protected subscribeGameEvent(): void {
     super.subscribeGameEvent()
-    this.bus.subscribeEvent('alchemyItemRegister', this.onAlchemyItemRegister.bind(this))
   }
 
   protected unsubscribeGameEvent(): void {
     super.unsubscribeGameEvent()
-    this.bus.unsubscribeEvent('alchemyItemRegister', this.onAlchemyItemRegister.bind(this))
   }
 
   private readonly onAlchemyItemRegister = (ev: AlchemyItemRegisterEvent): void => {

--- a/churaverse-plugins-server/src/churarenPlugin/churarenItemPlugin/alchemyItemManager.ts
+++ b/churaverse-plugins-server/src/churarenPlugin/churarenItemPlugin/alchemyItemManager.ts
@@ -15,6 +15,11 @@ export class AlchemyItemManager implements IAlchemyItemRegister, IAlchemyItemMan
   }
 
   public register(recipe: AlchemyItemRecipe, kind: AlchemyItemKind): void {
+    if (recipe.pattern === 'all_diff') {
+      this.alchemyItemRegistry.registerAllDiff(kind)
+      return
+    }
+
     const pendingRecipe = this.pendingRecipes.get(recipe.materialKind) ?? {}
 
     if (recipe.pattern === 'all_same') {
@@ -66,7 +71,7 @@ export class AlchemyItemManager implements IAlchemyItemRegister, IAlchemyItemMan
       const sortedKinds = [...countKinds.entries()].sort((a, b) => b[1] - a[1])
       return this.get({ pattern: 'two_same_one_diff', materialKind: sortedKinds[0][0] as ItemKind })
     } else if (itemCount === 3) {
-      return 'blackHole'
+      return this.get({ pattern: 'all_diff', materialKind: materialItems[0] })
     }
 
     return 'blackHole'

--- a/churaverse-plugins-server/src/churarenPlugin/churarenItemPlugin/alchemyItemRegistry.ts
+++ b/churaverse-plugins-server/src/churarenPlugin/churarenItemPlugin/alchemyItemRegistry.ts
@@ -9,6 +9,7 @@ export interface AlchemyItemRecipeRecord {
 
 export class AlchemyItemRegistry {
   private readonly alchemyItemRecipes = new Map<string, AlchemyItemRecipeRecord>()
+  private allDiffItem: AlchemyItemKind | undefined
 
   public register(materialItem: ItemKind, recipeRecord: AlchemyItemRecipeRecord): void {
     if (this.alchemyItemRecipes.has(materialItem)) {
@@ -17,7 +18,14 @@ export class AlchemyItemRegistry {
     this.alchemyItemRecipes.set(materialItem, recipeRecord)
   }
 
+  public registerAllDiff(kind: AlchemyItemKind): void {
+    this.allDiffItem = kind
+  }
+
   public get(recipe: AlchemyItemRecipe): AlchemyItemKind | undefined {
+    if (recipe.pattern === 'all_diff') {
+      return this.allDiffItem
+    }
     const record = this.alchemyItemRecipes.get(recipe.materialKind)
 
     switch (recipe.pattern) {

--- a/churaverse-plugins-server/src/churarenPlugin/churarenItemPlugin/churarenItemPlugin.ts
+++ b/churaverse-plugins-server/src/churarenPlugin/churarenItemPlugin/churarenItemPlugin.ts
@@ -59,6 +59,7 @@ export class ChurarenItemPlugin extends BaseGamePlugin {
     initItemPluginStore(this.store)
     this.itemPluginStore = this.store.of('churarenItemPlugin')
     this.networkPluginStore = this.store.of('networkPlugin')
+    this.bus.post(new AlchemyItemRegisterEvent(this.itemPluginStore.alchemyItemRegister))
   }
 
   private readonly update = (): void => {
@@ -69,7 +70,6 @@ export class ChurarenItemPlugin extends BaseGamePlugin {
 
   protected handleGameStart(): void {
     this.churarenGameInfo = this.store.of('gamePlugin').games.get(this.gameId)
-    this.bus.post(new AlchemyItemRegisterEvent(this.itemPluginStore.alchemyItemRegister))
   }
 
   protected handleGameTermination(): void {

--- a/churaverse-plugins-server/src/churarenPlugin/churarenItemPlugin/interface/IAlchemyItemRecipe.ts
+++ b/churaverse-plugins-server/src/churarenPlugin/churarenItemPlugin/interface/IAlchemyItemRecipe.ts
@@ -16,6 +16,6 @@ export type AlchemyItemGenerateType = 'all_same' | 'two_same_one_diff' | 'all_di
  * @param materialKind 錬金アイテムを生成するための素材アイテムの種類 (`pattern`が`all_diff`の場合はこの種類は影響しない)
  */
 export interface AlchemyItemRecipe {
-  readonly pattern: Omit<AlchemyItemGenerateType, 'all_diff'>
+  readonly pattern: AlchemyItemGenerateType
   readonly materialKind: ItemKind
 }


### PR DESCRIPTION
CV-723をマージしたことにより、錬金アイテムが必ずブラックホールになってしまうバグが発生

- 原因
ブラックホールのレシピがなかったことにより、別のレシピを上書きするような感じになっていた。

- 修正
ブラックホール用のレシピの追加
他の錬金アイテム同様にメソッド名が一部前バージョンのものだったので変更
イベント購読のタイミングにより、イベント発火しても受信しなかったのでずれの修正