### PR TITLE
Fix/cv 923/water ring not cleared after use

### DIFF
--- a/churaverse-plugins-client/src/churarenPlugin/churarenAlchemyItems/waterRingPlugin/renderer/waterRingAttackRenderer.ts
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenAlchemyItems/waterRingPlugin/renderer/waterRingAttackRenderer.ts
@@ -8,10 +8,6 @@ import waterRingAttackImage from '../assets/waterRingAttack.png'
  */
 const WATER_RING_ATTACK_TEXTURE_KEY = 'waterRingAttack'
 
-/**
- * 水の輪のアニメーションキー
- */
-const WATER_RING_ATTACK_ANIM_KEY = 'waterRingAttackAnimation'
 
 /**
  * 表示時の縦横のサイズ
@@ -48,9 +44,10 @@ export class WaterRingAttackRenderer implements IWaterRingAttackRenderer {
 
     // アニメーションの設定配列から各アニメーションを生成
     _anims.forEach((cfg) => {
+      if (scene.anims.exists(cfg.key)) return
       scene.anims.create({
         key: cfg.key,
-        frames: this.scene.anims.generateFrameNumbers(WATER_RING_ATTACK_ANIM_KEY, {
+        frames: this.scene.anims.generateFrameNumbers(WATER_RING_ATTACK_TEXTURE_KEY, {
           start: cfg.frameStart,
           end: cfg.frameEnd,
         }),

--- a/churaverse-plugins-client/src/churarenPlugin/churarenAlchemyItems/waterRingPlugin/waterRingPlugin.ts
+++ b/churaverse-plugins-client/src/churarenPlugin/churarenAlchemyItems/waterRingPlugin/waterRingPlugin.ts
@@ -88,12 +88,12 @@ export class WaterRingPlugin extends BaseAlchemyItemPlugin {
   }
 
   protected handleGameTermination(): void {
-    resetWaterRingPluginStore(this.store)
     this.socketController?.unregisterMessageListener()
     this.clearWaterRing()
+    resetWaterRingPluginStore(this.store)
   }
 
-  protected handleMidwayParticipant(): void {
+  protected handleMidwayJoin(): void {
     this.unsubscribeGameEvent()
   }
 
@@ -167,6 +167,7 @@ export class WaterRingPlugin extends BaseAlchemyItemPlugin {
     waterRing?.die()
     waterRingAttackRenderer?.dead()
     this.waterRingPluginStore.waterRings.delete(waterRing.waterRingId)
+    this.waterRingPluginStore.waterRingAttackRenderers.delete(waterRing.waterRingId)
   }
 
   // 水の輪の出現を受信した時の処理


### PR DESCRIPTION
- 問題
waterRingが使用しても破棄されず、無限に使えるバグ

- 修正内容
描画の時にスプライトシートのロードと同じ、変数を渡す必要があるところを別の変数を渡していたのでそこの修正

- 他の修正に関して
storeを先に削除した後に、storeを使用して別のものを削除するようにしていたりしたので順番を変更
プレイヤーが死んだら、mapが破棄されるコードがなかったので追加