### PR TITLE
setTiemoutのidを受け取り、ゲーム終了時にはタイマーは破棄するように変更

### DIFF
--- a/churaverse-plugins-server/src/churarenPlugin/churarenCorePlugin/churarenCorePlugin.ts
+++ b/churaverse-plugins-server/src/churarenPlugin/churarenCorePlugin/churarenCorePlugin.ts
@@ -22,6 +22,8 @@ export class ChurarenCorePlugin extends CoreGamePlugin {
   private socketController?: SocketController
   private networkPluginStore!: NetworkPluginStore<IMainScene>
 
+  private resultDisplayTimeoutId: ReturnType<typeof setTimeout> | undefined
+
   public listenEvent(): void {
     super.listenEvent()
     this.bus.subscribeEvent('init', this.init.bind(this))
@@ -76,6 +78,8 @@ export class ChurarenCorePlugin extends CoreGamePlugin {
    * 中断・終了時に実行される処理
    */
   protected handleGameTermination(): void {
+    clearTimeout(this.resultDisplayTimeoutId)
+    this.resultDisplayTimeoutId = undefined
     this.store.deleteStoreOf('churarenPlugin')
     this.socketController?.unregisterMessageListener()
   }
@@ -109,7 +113,7 @@ export class ChurarenCorePlugin extends CoreGamePlugin {
    */
   private readonly sendChurarenResult = (ev: ChurarenResultEvent): void => {
     this.networkPluginStore.messageSender.send(new ChurarenResultMessage({ resultType: ev.resultType }))
-    setTimeout(() => {
+    this.resultDisplayTimeoutId = setTimeout(() => {
       if (!this.isActive) return
       this.bus.post(new GameEndEvent(this.gameId))
     }, RESULT_DISPLAY_TIME_SECONDS * 1000)


### PR DESCRIPTION
ちゅられんで攻撃を受けて死亡して、ゲームが終わった後に再度ゲームを開始すると数秒でゲームが終わるバグ
- 原因
ゲーム終了後に完全にちゅられんを終わるために、setTimeoutで15秒ごに消去するように書かれていた。
15秒以内に、ゲームを再起動するとそのsetTimeoutがゲームを強制終了させてしまう

- 解決法
setTimeoutの戻り値として、idを受け取りちゅられんゲーム終了次にそのidを使ってsetTimeoutを削除するように変更

https://churadata.backlog.com/view/CV-924